### PR TITLE
Modernize Asterism: command registry, rate-limit gate, redeploy spam guard, type-checked JSDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .env
 tracked_users.json
 bot.db
+bot.db.backup
 bot.lock
 config.json
 AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ tracked_users.json
 bot.db
 bot.lock
 config.json
-AGENTS.md 
+AGENTS.md
 DEPLOYING.md

--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ Optional but recommended: **Manage Webhooks**. Without it, the bot can still pos
 ## How it runs
 
 - **Single-instance lock**: `bot.lock` is written on startup with the current PID. If a live PID already owns the lock, the new process exits with code 1. Stale locks (dead PID) are cleared automatically. This stops Replit's Run + Deploy from spawning two bots.
-- **Database**: SQLite in WAL mode at `$REPL_HOME/bot.db` (or `./bot.db` locally). Migrations are idempotent `ALTER TABLE` checks on startup.
+- **Database**: SQLite in WAL mode at `$REPL_HOME/bot.db` (or `./bot.db` locally). Migrations are idempotent `ALTER TABLE` checks on startup. A `bot.db.backup` snapshot is written once at startup and weekly thereafter — coarse insurance, not point-in-time recovery.
 - **Polling**: every 10 minutes, every tracked user gets one combined GraphQL call (profile data is folded into the same request once a day). On bot startup, every tracked user gets one immediate check before the interval kicks in.
+- **Startup catch-up**: on the first successful poll after the bot launches, any pending backlog of more than one new activity is summarised down to the single most recent — so a redeploy can't flood the channel.
+- **Rate-limit gate**: a 429 from AniList sets a process-wide window read from `X-RateLimit-Reset`; every subsequent fetch (polling and commands) short-circuits with a "try again in ~Xs" reply until the window passes.
 - **Posting**: at most 15 activities per user per tick. Oldest first. Filtered by the per-user `anime`/`manga`/`both` preference.
 - **Shutdown**: SIGINT, SIGTERM, SIGQUIT, and SIGHUP all checkpoint the WAL, close the database, and clear the lock file.
 
@@ -113,11 +115,16 @@ The same AniList user can be tracked in multiple channels independently. Each ch
 
 ```
 Asterism/
-├── index.js              Main bot: lock, DB, commands, polling loop
+├── index.js              Lock, DB, polling loop, dispatcher
 ├── deploy-commands.js    One-shot slash command registration
+├── commands/             One file per slash command (auto-loaded)
+├── lib/
+│   ├── anilist.js        AniList GraphQL client + rate-limit gate
+│   └── types.js          JSDoc typedefs (TrackedUser, CommandCtx, …)
 ├── package.json
-├── config.json           Not in git — you create it
+├── config.json           Optional — token can be in env vars instead
 ├── bot.db                SQLite database, auto-created
+├── bot.db.backup         Weekly snapshot of bot.db
 ├── bot.lock              PID lock, auto-managed
 ├── README.md
 ├── TERMS.md

--- a/README.md
+++ b/README.md
@@ -1,333 +1,146 @@
-# Asterism - AniList Discord Bot
+# Asterism
 
-A Discord bot that tracks AniList user activity and posts updates to Discord channels in real-time. Get notified when users update their anime/manga lists, complete episodes, or change their watching status. Features webhook-based activity posts, user statistics, profile customization, and robust data persistence!
+A Discord bot that watches AniList users and re-posts their anime/manga list activity into your channels — as the user, with their avatar and profile color, not as a bland bot embed.
 
-## ✨ Features
+It runs on Node.js, stores its state in SQLite, polls AniList every ten minutes, and stays out of your way.
 
-### Core Functionality
-- 🎭 **Webhook-Based Posts**: Activity updates appear as if posted by the actual user (with their avatar and username)
-- 📊 **Rich Embeds**: Beautiful Discord embeds with anime cover images and metadata
-- 🔍 **Batch Activity Tracking**: Shows ALL activities between checks (up to 15 at once)
-- ⏱️ **10-Minute Intervals**: Efficient monitoring with reduced API load
-- 🎨 **Profile Customization**: Respects user's AniList profile colors and title language preferences
-- 💾 **Persistent Storage**: SQLite with WAL mode ensures data survives crashes and restarts
+---
 
-### User Experience
-- ⚡ **Slash Commands**: Modern Discord slash command interface
-- 🌐 **Title Language Support**: Shows titles in user's preferred language (Romaji/English/Native)
-- 📈 **Statistics Commands**: View detailed stats for individual users or entire server
-- 🎯 **Channel-Specific**: Track different users in different Discord channels
-- 🔒 **Smart Privacy**: Ephemeral replies for management commands
-- 🛡️ **Error Resilience**: Advanced error handling prevents crashes
+## What it actually does
 
-### Technical Excellence
-- 🔄 **Profile Caching**: 24-hour cache reduces API calls by 98%
-- 💪 **Graceful Shutdown**: Proper database closure on restart
-- 🔐 **Permission Handling**: Automatic fallback when webhook permissions unavailable
-- 📝 **Database Verification**: All writes are verified and checkpointed
-- 🚀 **Immediate Startup Check**: No 10-minute wait after bot restarts
+You run `/track <username>` in a channel. From that moment, every ten minutes Asterism asks AniList what that user has been up to. When they finish an episode, drop a chapter, plan a watch, anything that hits their list, the bot posts a small embed in your channel — using a webhook so the post wears the user's name and AniList avatar.
 
-## 📋 Commands
+If the bot has the **Manage Webhooks** permission, posts are impersonated. If not, the same embed shows up under the bot's own name. Nothing breaks; it just looks less authentic.
+
+It also tracks per-channel preferences: filter by anime only, manga only, or both. Title language follows whatever the AniList user has set (Romaji, English, Native).
+
+---
+
+## Commands
 
 | Command | Description | Visibility |
-|---------|-------------|------------|
-| `/track <username>` | Start tracking an AniList user in the current channel | Public |
-| `/untrack <username>` | Stop tracking a specific user in the current channel | Private |
-| `/list` | Show all AniList users currently being tracked in this channel | Private |
-| `/stats <username>` | Display detailed statistics for any AniList user | Public |
-| `/serverstats` | Show combined statistics for all tracked users in the server | Public |
-| `/help` | Display available commands with detailed descriptions | Private |
+|---|---|---|
+| `/track <username> [filter]` | Start tracking a user. Filter is `both` (default), `anime`, or `manga`. | Public |
+| `/untrack <username>` | Stop tracking a user in the current channel. | Ephemeral |
+| `/list` | Show who is being tracked in this channel. | Ephemeral |
+| `/stats <username>` | Detailed stats for any AniList user (not just tracked ones). | Public |
+| `/serverstats` | Aggregate stats and a leaderboard for everyone tracked in the server. | Public |
+| `/help` | Lists the commands. | Ephemeral |
 
-**🔒 Privacy Notes:**
-- **Public commands**: Visible to everyone in the channel
-- **Private commands**: Ephemeral replies (only you can see)
-- Activity updates use webhooks when available for authentic appearance
+---
 
-## 🎨 What Makes It Special
+## Setup
 
-### Webhook-Based Activity Posts
-Activity updates appear with the **user's actual AniList avatar and username**, making it look like they posted it themselves:
+You need Node.js 20+ and a Discord application.
 
-```
-👤 BlankIts [with their AniList avatar]
-├─ BlankIts's Activity [clickable profile link]
-├─ read chapter 26 - Smoking Behind the Supermarket with You
-├─ [Manga cover image]
-└─ 🤖 Asterism • From AniList • 5:14 AM
-```
-
-### Profile Customization
-- **Colors**: Uses each user's AniList profile color for embeds
-- **Avatars**: Shows user's AniList profile picture
-- **Title Language**: Respects user's preference (Romaji/English/Native)
-- **Automatic Updates**: Profile data cached for 24 hours, then refreshed
-
-### Statistics Commands
-
-**`/stats <username>`** shows:
-- Anime statistics (count, episodes watched, days watched, mean score)
-- Manga statistics (count, chapters read, volumes read, mean score)
-- Top 3 favorite anime, manga, and favorite character
-- User's banner image (if they have one)
-
-**`/serverstats`** shows:
-- Combined stats for all tracked users in the server
-- Total anime/manga watched across everyone
-- Total episodes and chapters
-- Top 5 anime watchers with avatars and profile links
-
-## 🚀 Setup
-
-### Prerequisites
-
-- Node.js (v16 or higher)
-- Discord Bot Token
-- Discord Developer Application
-- SQLite3 (included in dependencies)
-
-### Installation
-
-1. **Clone the repository**
+1. Clone and install:
    ```bash
    git clone https://github.com/Abdullah-Mehdi/Asterism.git
    cd Asterism
-   ```
-
-2. **Install dependencies**
-   ```bash
    npm install
    ```
 
-3. **Create a Discord Bot**
-   - Go to the [Discord Developer Portal](https://discord.com/developers/applications)
-   - Create a new application
-   - Go to the "Bot" section
-   - Create a bot and copy the token
-   - Get your Application ID (Client ID) from the "General Information" tab
+2. Create the bot in the [Discord Developer Portal](https://discord.com/developers/applications). Grab the application ID and bot token.
 
-4. **Set up configuration**
-   Create a `config.json` file in the root directory:
+3. Drop a `config.json` in the project root:
    ```json
    {
-     "clientId": "your_application_id_here",
-     "token": "your_discord_bot_token_here"
+     "clientId": "your_application_id",
+     "token":    "your_bot_token"
    }
    ```
 
-5. **Register slash commands**
+4. Register the slash commands once (and again any time you change `deploy-commands.js`):
    ```bash
    node deploy-commands.js
    ```
-   This registers `/track`, `/untrack`, `/list`, `/stats`, `/serverstats`, and `/help` commands globally.
+   Global commands take 5 to 15 minutes to propagate to Discord clients.
 
-6. **Invite the bot to your server**
-   - In the Discord Developer Portal, go to OAuth2 > URL Generator
-   - Select scopes: `bot` and `applications.commands`
-   - Select permissions:
-     - ✅ Send Messages
-     - ✅ Embed Links
-     - ✅ Manage Webhooks (for webhook-based posts)
-     - ✅ Use Slash Commands
-   - Use the generated URL to invite the bot
+5. Invite the bot. In the Developer Portal, OAuth2 → URL Generator, pick scopes `bot` and `applications.commands`, then permissions: Send Messages, Embed Links, Use Slash Commands, and (recommended) Manage Webhooks.
 
-7. **Run the bot**
+6. Run it:
    ```bash
-   node index.js
+   npm start
    ```
 
-## 🔧 Bot Permissions
+For Replit deployment specifics, see [DEPLOYING.md](./DEPLOYING.md) — but it's not in this repo's git tree, so it's only relevant if you're me.
 
-### Required Permissions
-- **Send Messages**: To post activity updates
-- **Embed Links**: To send rich embed messages
-- **Use Slash Commands**: To respond to slash commands
+---
 
-### Optional (Recommended)
-- **Manage Webhooks**: For webhook-based activity posts (with user avatars)
-  - If not granted, bot automatically falls back to regular messages
-  - Activity updates still work, just appear from the bot instead
+## Permissions
 
-## 📊 How It Works
+Required: **Send Messages**, **Embed Links**, **Use Slash Commands**.
 
-### Database & Performance
-1. **Startup**: Loads all tracked users from SQLite database into memory
-2. **WAL Mode**: Uses Write-Ahead Logging for crash resistance
-3. **Periodic Checkpoints**: Database synced every 30 minutes
-4. **Graceful Shutdown**: Proper database closure on SIGTERM/SIGINT signals
-5. **Profile Caching**: User profiles cached for 24 hours (reduces API calls by 98%)
+Optional but recommended: **Manage Webhooks**. Without it, the bot can still post — it just can't impersonate. Activity embeds show up under the bot's own identity. Everything else is identical.
 
-### Activity Monitoring
-1. **Immediate Check**: Runs check immediately on startup
-2. **10-Minute Interval**: Checks all tracked users every 10 minutes
-3. **Batch Detection**: Finds ALL new activities since last check (up to 15 shown)
-4. **Chronological Order**: Posts activities oldest-to-newest
-5. **Smart Updates**: Only posts new activities, never duplicates
+---
 
-### Webhook System
-1. **Creation**: Creates one webhook per channel (cached)
-2. **Verification**: Validates webhook exists before each use
-3. **Fallback**: Automatically uses regular messages if webhooks fail
-4. **Recovery**: Recreates broken webhooks automatically
-5. **Permissions**: Gracefully handles missing webhook permissions
+## How it runs
 
-## 🗄️ Database Schema
+- **Single-instance lock**: `bot.lock` is written on startup with the current PID. If a live PID already owns the lock, the new process exits with code 1. Stale locks (dead PID) are cleared automatically. This stops Replit's Run + Deploy from spawning two bots.
+- **Database**: SQLite in WAL mode at `$REPL_HOME/bot.db` (or `./bot.db` locally). Migrations are idempotent `ALTER TABLE` checks on startup.
+- **Polling**: every 10 minutes, every tracked user gets one combined GraphQL call (profile data is folded into the same request once a day). On bot startup, every tracked user gets one immediate check before the interval kicks in.
+- **Posting**: at most 15 activities per user per tick. Oldest first. Filtered by the per-user `anime`/`manga`/`both` preference.
+- **Shutdown**: SIGINT, SIGTERM, SIGQUIT, and SIGHUP all checkpoint the WAL, close the database, and clear the lock file.
+
+---
+
+## Database schema
 
 ```sql
 CREATE TABLE tracked_users (
-    channelId TEXT NOT NULL,           -- Discord channel ID
-    anilistUserId INTEGER NOT NULL,    -- AniList user ID
-    anilistUsername TEXT NOT NULL,     -- AniList username
-    lastActivityId INTEGER,            -- Last tracked activity ID
-    userAvatar TEXT,                   -- Cached AniList avatar URL
-    userColor TEXT,                    -- Cached profile color
-    titleLanguage TEXT,                -- Title language preference
-    profileLastUpdated INTEGER,        -- Cache timestamp
+    channelId          TEXT    NOT NULL,
+    anilistUserId      INTEGER NOT NULL,
+    anilistUsername    TEXT    NOT NULL,
+    lastActivityId     INTEGER,
+    userAvatar         TEXT,
+    userColor          TEXT,
+    titleLanguage      TEXT    DEFAULT 'ROMAJI',
+    profileLastUpdated INTEGER,
+    activityFilter     TEXT    DEFAULT 'both',
     PRIMARY KEY (channelId, anilistUserId)
 );
 ```
 
-## 📦 Project Structure
+The same AniList user can be tracked in multiple channels independently. Each channel gets its own row.
+
+---
+
+## Project layout
 
 ```
 Asterism/
-├── index.js              # Main bot with slash commands, webhooks, and database
-├── deploy-commands.js    # Slash command registration script
-├── package.json          # Dependencies and project metadata
-├── config.json           # Bot configuration (you create this)
-├── bot.db               # SQLite database (auto-generated)
-├── README.md            # This file
-├── TERMS.md             # Terms of Service
-├── PRIVACY.md           # Privacy Policy
-└── .gitignore           # Git ignore rules
+├── index.js              Main bot: lock, DB, commands, polling loop
+├── deploy-commands.js    One-shot slash command registration
+├── package.json
+├── config.json           Not in git — you create it
+├── bot.db                SQLite database, auto-created
+├── bot.lock              PID lock, auto-managed
+├── README.md
+├── TERMS.md
+└── PRIVACY.md
 ```
 
-## 🔌 API Integration
+---
 
-### AniList GraphQL API
-- **User Profiles**: Avatars, colors, title language preferences
-- **Activity Feed**: Latest anime/manga list updates
-- **Statistics**: Anime/manga counts, episodes, scores
-- **Media Information**: Titles, cover images, URLs
-- **Rate Limit Friendly**: 98% reduction in API calls via caching
+## Troubleshooting
 
-### Discord API
-- **Slash Commands**: Modern command interface
-- **Webhooks**: User-impersonation for activity posts
-- **Embeds**: Rich message formatting
-- **Ephemeral Messages**: Private command responses
+**Slash commands aren't showing up.** Wait 15 minutes. If still nothing, re-run `node deploy-commands.js` and confirm `clientId` in `config.json` matches the application the bot is actually logged in as.
 
-## 📈 Performance
+**`/track` says "Could not find user".** The AniList API returned no result. Check spelling on https://anilist.co.
 
-### API Call Optimization
-- **Before caching**: ~2 calls per user per check (720 calls/day for 6 users)
-- **After caching**: ~0.04 calls per user per check (14 calls/day for 6 users)
-- **Reduction**: 98% fewer API calls
+**Posts stopped appearing.** Check the logs for the per-tick `Checking for new AniList activity...` line. If absent, the process is dead — restart. If present but no posts, the bot likely lost Manage Webhooks in that channel; check for `⚠️ Missing MANAGE_WEBHOOKS permission` lines.
 
-### Activity Handling
-- **Check Interval**: 10 minutes (reduced from 5 minutes)
-- **Batch Limit**: Up to 15 activities shown per check
-- **Concurrent**: All tracked users checked in parallel
+**Two bots are posting.** Two processes are running. On Replit, that means Run and Deploy are both live — stop Run. Locally, kill stray `node` processes.
 
-## 🛠️ Configuration Options
+**Database "lost" all my tracked users after a restart.** Confirm the DB path in the logs lives under `$REPL_HOME` (not `./bot.db`). On Replit, this means deploying to **Reserved VM**, not Autoscale — Autoscale wipes the filesystem.
 
-### Check Interval
-Change line 363 in `index.js`:
-```javascript
-}, 600000); // 10 minutes (600000ms)
-```
+---
 
-### Activity Display Limit
-Change line 245 in `index.js`:
-```javascript
-const activitiesToShow = newActivities.slice(0, 15); // Show 15 max
-```
+## Legal
 
-### Profile Cache Duration
-Change line 26 in `index.js`:
-```javascript
-const PROFILE_CACHE_DURATION = 86400000; // 24 hours
-```
+- [Terms of Service](./TERMS.md)
+- [Privacy Policy](./PRIVACY.md)
+- Licensed under ISC.
 
-## 🐛 Troubleshooting
-
-### Double Posts
-- **Cause**: Multiple bot instances running
-- **Fix**: Run `pkill -9 node` on Replit, then restart
-
-### Missing Webhook Posts
-- **Cause**: Bot lacks "Manage Webhooks" permission
-- **Behavior**: Automatically falls back to regular messages
-- **Fix**: Re-invite bot with updated permissions
-
-### Database Not Persisting
-- **Cause**: WAL file not checkpointed
-- **Fix**: Bot now auto-checkpoints every 30 minutes + on shutdown
-
-### Commands Not Appearing
-- **Cause**: Commands not registered with Discord
-- **Fix**: Run `node deploy-commands.js`
-- **Wait**: Global commands take 5-15 minutes to propagate
-
-## 📜 Legal
-
-- **Terms of Service**: [TERMS.md](./TERMS.md)
-- **Privacy Policy**: [PRIVACY.md](./PRIVACY.md)
-
-## 🚀 Recent Updates (v4.0)
-
-### ✨ New Features
-- **Webhook-based activity posts** with user avatars and usernames
-- **Profile customization** (colors, avatars, title languages)
-- **`/stats` command** for individual user statistics
-- **`/serverstats` command** for server-wide analytics
-- **Batch activity tracking** (shows all activities between checks)
-- **Profile caching** (24-hour cache, 98% API reduction)
-
-### 🔧 Technical Improvements
-- **10-minute check interval** (reduced load)
-- **WAL mode** for database crash resistance
-- **Periodic checkpointing** for data persistence
-- **Graceful shutdown** handling
-- **Immediate startup check** (no waiting period)
-- **Activity cap** at 15 to prevent spam
-- **Webhook fallback** system with auto-recovery
-
-### 🛡️ Stability Enhancements
-- **Double-post prevention** with edge case handling
-- **Database write verification** on all operations
-- **Better error messages** with detailed logging
-- **Permission graceful degradation**
-- **Network error resilience**
-
-## 🔮 Potential Future Features
-
-- Activity filtering (anime-only, manga-only, by status)
-- Weekly digest mode
-- User comparison features
-- Seasonal tracking
-- Custom activity templates
-- Role-based access control
-- Multi-server dashboard
-- Rate limit dashboard
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 📞 Support
-
-- **Issues**: [GitHub Issues](https://github.com/Abdullah-Mehdi/Asterism/issues)
-- **AniList API**: [Documentation](https://anilist.gitbook.io/anilist-apiv2-docs/)
-- **Discord.js**: [Documentation](https://discord.js.org/)
-
-## ⚖️ License
-
-This project is licensed under the ISC License - see the LICENSE file for details.
-
-## 📝 Disclaimer
-
-This bot is not affiliated with AniList or Discord. It uses the public AniList API and Discord API in accordance with their respective terms of service.
+This bot is not affiliated with AniList or Discord. It uses the public AniList GraphQL API and the Discord API in line with their terms.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ You need Node.js 20+ and a Discord application.
 
 2. Create the bot in the [Discord Developer Portal](https://discord.com/developers/applications). Grab the application ID and bot token.
 
-3. Drop a `config.json` in the project root:
-   ```json
-   {
-     "clientId": "your_application_id",
-     "token":    "your_bot_token"
-   }
-   ```
+3. Provide the credentials. Two options — pick whichever fits your environment:
+   - **Environment variables** (preferred on Replit, where they live in Secrets and stay encrypted): `DISCORD_TOKEN` and `DISCORD_CLIENT_ID`.
+   - **`config.json`** in the project root, used as a fallback when the env vars are missing:
+     ```json
+     {
+       "clientId": "your_application_id",
+       "token":    "your_bot_token"
+     }
+     ```
+   Env wins if both are set. The file is optional — if env vars cover both, you don't need it at all.
 
 4. Register the slash commands once (and again any time you change `deploy-commands.js`):
    ```bash

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+
+/**
+ * Render `/track <username> [filter]` style usage from a command's option list.
+ * Required options get angle brackets, optional ones get square brackets.
+ */
+function commandUsage(cmd) {
+    const data = cmd.data.toJSON();
+    const opts = (data.options || [])
+        .map(o => o.required ? `<${o.name}>` : `[${o.name}]`)
+        .join(" ");
+    return opts ? `/${data.name} ${opts}` : `/${data.name}`;
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("help")
+        .setDescription("Displays a list of all available commands."),
+    ephemeral: true,
+    async execute(interaction, ctx) {
+        const helpEmbed = new EmbedBuilder()
+            .setColor("#C3B1E1")
+            .setTitle("AniList Bot Commands")
+            .addFields(
+                ctx.commands.map(c => ({
+                    name: commandUsage(c),
+                    value: c.data.toJSON().description,
+                }))
+            );
+        await interaction.editReply({ embeds: [helpEmbed] });
+    },
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,8 +1,12 @@
+// @ts-check
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 
 /**
  * Render `/track <username> [filter]` style usage from a command's option list.
  * Required options get angle brackets, optional ones get square brackets.
+ *
+ * @param {import("../lib/types").CommandModule} cmd
+ * @returns {string}
  */
 function commandUsage(cmd) {
     const data = cmd.data.toJSON();
@@ -17,6 +21,10 @@ module.exports = {
         .setName("help")
         .setDescription("Displays a list of all available commands."),
     ephemeral: true,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     * @param {import("../lib/types").CommandCtx} ctx
+     */
     async execute(interaction, ctx) {
         const helpEmbed = new EmbedBuilder()
             .setColor("#C3B1E1")

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Auto-loader: every sibling .js file becomes a registered command.
 // Order is alphabetical by filename so /help renders predictably.
 // Drop a new file with `{ data, ephemeral, execute }` and it gets picked up

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,0 +1,14 @@
+// Auto-loader: every sibling .js file becomes a registered command.
+// Order is alphabetical by filename so /help renders predictably.
+// Drop a new file with `{ data, ephemeral, execute }` and it gets picked up
+// on the next process start — no edits to this file or to index.js needed.
+
+const fs = require("fs");
+const path = require("path");
+
+const commands = fs.readdirSync(__dirname)
+    .filter(f => f.endsWith(".js") && f !== "index.js")
+    .sort()
+    .map(f => require(path.join(__dirname, f)));
+
+module.exports = commands;

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 
 module.exports = {
@@ -5,6 +6,10 @@ module.exports = {
         .setName("list")
         .setDescription("Shows all AniList users currently being tracked in this channel."),
     ephemeral: true,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     * @param {import("../lib/types").CommandCtx} ctx
+     */
     async execute(interaction, ctx) {
         const { trackedUsers } = ctx;
         const usersInChannel = trackedUsers[interaction.channelId];

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("list")
+        .setDescription("Shows all AniList users currently being tracked in this channel."),
+    ephemeral: true,
+    async execute(interaction, ctx) {
+        const { trackedUsers } = ctx;
+        const usersInChannel = trackedUsers[interaction.channelId];
+        const listEmbed = new EmbedBuilder()
+            .setColor("#C3B1E1")
+            .setTitle(`AniList Users Tracked in this Channel`);
+        if (usersInChannel && Object.keys(usersInChannel).length > 0) {
+            listEmbed.setDescription(
+                Object.values(usersInChannel)
+                    .map((user) => {
+                        const filterEmoji = user.activityFilter === "anime" ? "📺" :
+                                          user.activityFilter === "manga" ? "📖" : "📺📖";
+                        const filterText = user.activityFilter === "both" ? "" :
+                                         ` (${user.activityFilter} only)`;
+                        return `• ${filterEmoji} **${user.anilistUsername}**${filterText}`;
+                    })
+                    .join("\n"),
+            );
+        } else {
+            listEmbed.setDescription(
+                "No users are currently being tracked in this channel.",
+            );
+        }
+        await interaction.editReply({ embeds: [listEmbed] });
+    },
+};

--- a/commands/serverstats.js
+++ b/commands/serverstats.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 const { aniListFetch, getRateLimitRemainingMs } = require("../lib/anilist");
 
@@ -6,6 +7,10 @@ module.exports = {
         .setName("serverstats")
         .setDescription("Shows statistics for all tracked users in this server."),
     ephemeral: false,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     * @param {import("../lib/types").CommandCtx} ctx
+     */
     async execute(interaction, ctx) {
         const { client, trackedUsers } = ctx;
 

--- a/commands/serverstats.js
+++ b/commands/serverstats.js
@@ -1,0 +1,166 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const { aniListFetch, getRateLimitRemainingMs } = require("../lib/anilist");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("serverstats")
+        .setDescription("Shows statistics for all tracked users in this server."),
+    ephemeral: false,
+    async execute(interaction, ctx) {
+        const { client, trackedUsers } = ctx;
+
+        // Collect every unique AniList user tracked anywhere in this guild
+        // (a user may be tracked in multiple channels — dedupe by AniList ID).
+        const guildId = interaction.guildId;
+        const allChannelsInGuild = Object.keys(trackedUsers);
+        const uniqueUsers = new Map();
+
+        for (const channelId of allChannelsInGuild) {
+            try {
+                const channel = await client.channels.fetch(channelId);
+                if (channel && channel.guildId === guildId) {
+                    for (const userId in trackedUsers[channelId]) {
+                        const user = trackedUsers[channelId][userId];
+                        if (!uniqueUsers.has(userId)) {
+                            uniqueUsers.set(userId, user.anilistUsername);
+                        }
+                    }
+                }
+            } catch (error) {
+                // Channel inaccessible — skip silently and continue.
+                continue;
+            }
+        }
+
+        if (uniqueUsers.size === 0) {
+            return interaction.editReply(
+                "No users are currently being tracked in this server."
+            );
+        }
+
+        const userIds = Array.from(uniqueUsers.keys());
+        console.log(`Fetching server stats for ${userIds.length} users:`, userIds);
+
+        // AniList's schema doesn't expose a multi-User field, so we fan out
+        // one query per user and Promise.all the lot.
+        const userDataPromises = userIds.map(async (userId) => {
+            const userQuery = `query ($id: Int) {
+                User(id: $id) {
+                    id
+                    name
+                    avatar {
+                        medium
+                    }
+                    statistics {
+                        anime {
+                            count
+                            episodesWatched
+                            minutesWatched
+                            meanScore
+                        }
+                        manga {
+                            count
+                            chaptersRead
+                        }
+                    }
+                }
+            }`;
+
+            try {
+                const data = await aniListFetch(userQuery, { id: parseInt(userId) });
+                return data.data?.User || null;
+            } catch (error) {
+                if (error.name !== "RateLimitError") {
+                    console.error(`Error fetching user ${userId}:`, error);
+                }
+                return null;
+            }
+        });
+
+        try {
+            const usersData = await Promise.all(userDataPromises);
+            const users = usersData.filter(u => u !== null);
+
+            if (users.length === 0) {
+                // Distinguish rate-limit drought from genuine no-data.
+                const waitMs = getRateLimitRemainingMs();
+                if (waitMs > 0) {
+                    return interaction.editReply(
+                        `AniList is temporarily rate-limiting us. Try again in ~${Math.ceil(waitMs / 1000)}s.`
+                    );
+                }
+                return interaction.editReply(
+                    "No data available for tracked users in this server."
+                );
+            }
+
+            let totalAnime = 0;
+            let totalEpisodes = 0;
+            let totalManga = 0;
+            let totalChapters = 0;
+            let totalMinutes = 0;
+            let avgScore = 0;
+
+            users.forEach(user => {
+                totalAnime += user.statistics.anime.count;
+                totalEpisodes += user.statistics.anime.episodesWatched;
+                totalManga += user.statistics.manga.count;
+                totalChapters += user.statistics.manga.chaptersRead;
+                totalMinutes += user.statistics.anime.minutesWatched;
+                avgScore += user.statistics.anime.meanScore;
+            });
+
+            avgScore = (avgScore / users.length).toFixed(1);
+            const totalDays = (totalMinutes / 1440).toFixed(1);
+
+            const topWatchers = users
+                .sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)
+                .slice(0, 5)
+                .map((u, i) => {
+                    const avatarEmoji = u.avatar?.medium ? `[🎭](${u.avatar.medium})` : "👤";
+                    return `${i + 1}. ${avatarEmoji} **[${u.name}](https://anilist.co/user/${u.name})** - ${u.statistics.anime.count} anime`;
+                })
+                .join("\n");
+
+            const topUser = users.sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)[0];
+
+            const serverStatsEmbed = new EmbedBuilder()
+                .setColor("#C3B1E1")
+                .setTitle(`📊 Server AniList Statistics`)
+                .setDescription(`Tracking **${uniqueUsers.size}** users in this server`)
+                .addFields(
+                    {
+                        name: "📺 Combined Anime Stats",
+                        value: [
+                            `**Total Anime Watched:** ${totalAnime.toLocaleString()}`,
+                            `**Total Episodes:** ${totalEpisodes.toLocaleString()}`,
+                            `**Total Days Watched:** ${totalDays}`,
+                            `**Average Score:** ${avgScore}`,
+                        ].join("\n"),
+                        inline: true,
+                    },
+                    {
+                        name: "📖 Combined Manga Stats",
+                        value: [
+                            `**Total Manga Read:** ${totalManga.toLocaleString()}`,
+                            `**Total Chapters:** ${totalChapters.toLocaleString()}`,
+                        ].join("\n"),
+                        inline: true,
+                    },
+                    {
+                        name: "🏆 Top Watchers",
+                        value: topWatchers,
+                    }
+                )
+                .setThumbnail(topUser?.avatar?.medium || null)
+                .setTimestamp();
+
+            await interaction.editReply({ embeds: [serverStatsEmbed] });
+        } catch (error) {
+            console.error("Error fetching server stats:", error.message, error.stack);
+            await interaction.editReply(
+                `There was an error fetching server statistics: ${error.message}`
+            );
+        }
+    },
+};

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 const { aniListFetch } = require("../lib/anilist");
 
@@ -10,8 +11,11 @@ module.exports = {
                 .setDescription("The AniList username to get stats for.")
                 .setRequired(true)),
     ephemeral: false,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     */
     async execute(interaction) {
-        const anilistUsername = interaction.options.getString("username");
+        const anilistUsername = interaction.options.getString("username", true);
 
         const statsQuery = `query ($username: String) {
             User(name: $username) {

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -1,0 +1,126 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const { aniListFetch } = require("../lib/anilist");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("stats")
+        .setDescription("Shows detailed statistics for an AniList user.")
+        .addStringOption(o =>
+            o.setName("username")
+                .setDescription("The AniList username to get stats for.")
+                .setRequired(true)),
+    ephemeral: false,
+    async execute(interaction) {
+        const anilistUsername = interaction.options.getString("username");
+
+        const statsQuery = `query ($username: String) {
+            User(name: $username) {
+                id
+                name
+                avatar { large }
+                bannerImage
+                statistics {
+                    anime {
+                        count
+                        episodesWatched
+                        minutesWatched
+                        meanScore
+                        standardDeviation
+                    }
+                    manga {
+                        count
+                        chaptersRead
+                        volumesRead
+                        meanScore
+                        standardDeviation
+                    }
+                }
+                favourites {
+                    anime { nodes { title { romaji } } }
+                    manga { nodes { title { romaji } } }
+                    characters { nodes { name { full } } }
+                }
+            }
+        }`;
+
+        try {
+            const data = await aniListFetch(statsQuery, { username: anilistUsername });
+
+            if (!data.data || !data.data.User) {
+                return interaction.editReply(
+                    `Could not find an AniList user with the username **${anilistUsername}**.`
+                );
+            }
+
+            const user = data.data.User;
+            const animeStats = user.statistics.anime;
+            const mangaStats = user.statistics.manga;
+
+            const daysWatched = (animeStats.minutesWatched / 1440).toFixed(1);
+
+            const favAnime = user.favourites.anime.nodes
+                .slice(0, 3)
+                .map(a => a.title.romaji)
+                .join(", ") || "None";
+
+            const favManga = user.favourites.manga.nodes
+                .slice(0, 3)
+                .map(m => m.title.romaji)
+                .join(", ") || "None";
+
+            const favChar = user.favourites.characters.nodes[0]?.name.full || "None";
+
+            const statsEmbed = new EmbedBuilder()
+                .setColor("#C3B1E1")
+                .setAuthor({
+                    name: `${user.name}'s AniList Statistics`,
+                    iconURL: user.avatar.large,
+                    url: `https://anilist.co/user/${user.name}/`,
+                })
+                .addFields(
+                    {
+                        name: "📺 Anime Statistics",
+                        value: [
+                            `**Total Anime:** ${animeStats.count}`,
+                            `**Episodes Watched:** ${animeStats.episodesWatched.toLocaleString()}`,
+                            `**Days Watched:** ${daysWatched}`,
+                            `**Mean Score:** ${animeStats.meanScore.toFixed(1)}`,
+                        ].join("\n"),
+                        inline: true,
+                    },
+                    {
+                        name: "📖 Manga Statistics",
+                        value: [
+                            `**Total Manga:** ${mangaStats.count}`,
+                            `**Chapters Read:** ${mangaStats.chaptersRead.toLocaleString()}`,
+                            `**Volumes Read:** ${mangaStats.volumesRead.toLocaleString()}`,
+                            `**Mean Score:** ${mangaStats.meanScore.toFixed(1)}`,
+                        ].join("\n"),
+                        inline: true,
+                    },
+                    {
+                        name: "⭐ Favorites",
+                        value: [
+                            `**Anime:** ${favAnime}`,
+                            `**Manga:** ${favManga}`,
+                            `**Character:** ${favChar}`,
+                        ].join("\n"),
+                    }
+                );
+
+            if (user.bannerImage) {
+                statsEmbed.setImage(user.bannerImage);
+            }
+
+            await interaction.editReply({ embeds: [statsEmbed] });
+        } catch (error) {
+            // Re-throw RateLimitError so the dispatcher's catch surfaces the
+            // friendly retry message; only swallow non-rate-limit errors here.
+            if (error.name === "RateLimitError") throw error;
+            console.error(`Error fetching stats for ${anilistUsername}:`, error);
+            await interaction.editReply(
+                `There was an error fetching statistics for **${anilistUsername}**.`
+            );
+        }
+    },
+};

--- a/commands/track.js
+++ b/commands/track.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { SlashCommandBuilder } = require("discord.js");
 const { aniListFetch } = require("../lib/anilist");
 
@@ -19,9 +20,15 @@ module.exports = {
                     { name: "Manga Only", value: "manga" },
                 )),
     ephemeral: false,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     * @param {import("../lib/types").CommandCtx} ctx
+     */
     async execute(interaction, ctx) {
         const { db, trackedUsers, checkAniListActivity } = ctx;
-        const anilistUsername = interaction.options.getString("username");
+        // Pass `true` as the second arg to assert "required" — narrows the
+        // return type from `string | null` to `string`.
+        const anilistUsername = interaction.options.getString("username", true);
         const activityFilter = interaction.options.getString("filter") || "both";
         const channelId = interaction.channelId;
 

--- a/commands/track.js
+++ b/commands/track.js
@@ -1,0 +1,101 @@
+const { SlashCommandBuilder } = require("discord.js");
+const { aniListFetch } = require("../lib/anilist");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("track")
+        .setDescription("Starts tracking an AniList user's activity in this channel.")
+        .addStringOption(o =>
+            o.setName("username")
+                .setDescription("The AniList username to track.")
+                .setRequired(true))
+        .addStringOption(o =>
+            o.setName("filter")
+                .setDescription("What type of activity to track (default: both)")
+                .setRequired(false)
+                .addChoices(
+                    { name: "Both Anime and Manga", value: "both" },
+                    { name: "Anime Only", value: "anime" },
+                    { name: "Manga Only", value: "manga" },
+                )),
+    ephemeral: false,
+    async execute(interaction, ctx) {
+        const { db, trackedUsers, checkAniListActivity } = ctx;
+        const anilistUsername = interaction.options.getString("username");
+        const activityFilter = interaction.options.getString("filter") || "both";
+        const channelId = interaction.channelId;
+
+        // Lookup ID + profile (avatar/color/titleLanguage) in a single query.
+        const findUserQuery = `query ($username: String) { 
+            User(name: $username) { 
+                id 
+                avatar { large }
+                options { profileColor, titleLanguage }
+            } 
+        }`;
+        const data = await aniListFetch(findUserQuery, { username: anilistUsername });
+        if (!data.data || !data.data.User)
+            return interaction.editReply(
+                `Could not find an AniList user with the username **${anilistUsername}**. Please check spelling.`,
+            );
+
+        const anilistUserId = data.data.User.id;
+        const userAvatar = data.data.User.avatar?.large;
+        const userColor = data.data.User.options?.profileColor;
+        const titleLanguage = data.data.User.options?.titleLanguage || "ROMAJI";
+        const now = Date.now();
+
+        if (trackedUsers[channelId]?.[anilistUserId])
+            return interaction.editReply(
+                `**${anilistUsername}** is already being tracked in this channel.`,
+            );
+
+        const sql = `INSERT INTO tracked_users (channelId, anilistUsername, anilistUserId, lastActivityId, userAvatar, userColor, titleLanguage, profileLastUpdated, activityFilter) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+        await db.run(sql, [
+            channelId,
+            anilistUsername,
+            anilistUserId,
+            null,
+            userAvatar,
+            userColor,
+            titleLanguage,
+            now,
+            activityFilter,
+        ]);
+
+        // FULL checkpoint — user-facing write, must survive a kill.
+        await db.exec("PRAGMA wal_checkpoint(FULL);");
+
+        const verification = await db.get(
+            `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
+            [channelId, anilistUserId]
+        );
+
+        if (verification) {
+            console.log(
+                `✓ [SUCCESS] Database write for ${anilistUsername} completed and verified.`,
+            );
+            if (!trackedUsers[channelId]) trackedUsers[channelId] = {};
+            trackedUsers[channelId][anilistUserId] = {
+                anilistUsername: anilistUsername,
+                lastActivityId: null,
+                userAvatar: userAvatar,
+                userColor: userColor,
+                titleLanguage: titleLanguage,
+                profileLastUpdated: now,
+                activityFilter: activityFilter,
+            };
+        } else {
+            console.error(
+                `✗ [ERROR] Database write verification failed for ${anilistUsername}!`,
+            );
+            throw new Error("Failed to persist user to database");
+        }
+        const filterText = activityFilter === "both" ? "all activity" :
+                          activityFilter === "anime" ? "anime only" : "manga only";
+        await interaction.editReply(
+            `Successfully found **${anilistUsername}**. Now tracking their ${filterText} in this channel!`,
+        );
+        checkAniListActivity(channelId, anilistUserId);
+    },
+};

--- a/commands/untrack.js
+++ b/commands/untrack.js
@@ -1,0 +1,74 @@
+const { SlashCommandBuilder } = require("discord.js");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("untrack")
+        .setDescription("Stops tracking a specific AniList user in this channel.")
+        .addStringOption(o =>
+            o.setName("username")
+                .setDescription("The AniList username to stop tracking.")
+                .setRequired(true)),
+    ephemeral: true,
+    async execute(interaction, ctx) {
+        const { db, trackedUsers, webhookCache, permissionsCache } = ctx;
+        const usernameToUntrack = interaction.options.getString("username");
+        const channelId = interaction.channelId;
+        const usersInChannel = trackedUsers[channelId];
+        if (!usersInChannel)
+            return interaction.editReply({
+                content: "No users are currently being tracked in this channel.",
+            });
+
+        let userToUntrackInfo = null;
+        let userIdToUntrack = null;
+        for (const userId in usersInChannel) {
+            if (
+                usersInChannel[userId].anilistUsername.toLowerCase() ===
+                usernameToUntrack.toLowerCase()
+            ) {
+                userToUntrackInfo = usersInChannel[userId];
+                userIdToUntrack = userId;
+                break;
+            }
+        }
+        if (!userToUntrackInfo)
+            return interaction.editReply({
+                content: `**${usernameToUntrack}** is not being tracked in this channel.`,
+            });
+
+        const sql = `DELETE FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`;
+        await db.run(sql, [channelId, userIdToUntrack]);
+
+        // FULL checkpoint — user-facing write, must survive a kill.
+        await db.exec("PRAGMA wal_checkpoint(FULL);");
+
+        const verification = await db.get(
+            `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
+            [channelId, userIdToUntrack]
+        );
+
+        if (!verification) {
+            console.log(
+                `✓ Successfully deleted ${userToUntrackInfo.anilistUsername} from database (verified).`,
+            );
+            delete trackedUsers[channelId][userIdToUntrack];
+            if (Object.keys(trackedUsers[channelId]).length === 0) {
+                delete trackedUsers[channelId];
+                // Channel ab khaali hai — per-channel caches bhi drop kar do
+                // taake long-running deploys mein stale entries jama na hon.
+                delete webhookCache[channelId];
+                delete permissionsCache[channelId];
+            }
+            await interaction.editReply(
+                `Stopped tracking **${userToUntrackInfo.anilistUsername}** in this channel.`,
+            );
+        } else {
+            console.error(
+                `✗ Database delete verification failed for ${userToUntrackInfo.anilistUsername}!`,
+            );
+            await interaction.editReply(
+                `Error: Failed to remove **${userToUntrackInfo.anilistUsername}** from database.`,
+            );
+        }
+    },
+};

--- a/commands/untrack.js
+++ b/commands/untrack.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { SlashCommandBuilder } = require("discord.js");
 
 module.exports = {
@@ -9,9 +10,13 @@ module.exports = {
                 .setDescription("The AniList username to stop tracking.")
                 .setRequired(true)),
     ephemeral: true,
+    /**
+     * @param {import("discord.js").ChatInputCommandInteraction} interaction
+     * @param {import("../lib/types").CommandCtx} ctx
+     */
     async execute(interaction, ctx) {
         const { db, trackedUsers, webhookCache, permissionsCache } = ctx;
-        const usernameToUntrack = interaction.options.getString("username");
+        const usernameToUntrack = interaction.options.getString("username", true);
         const channelId = interaction.channelId;
         const usersInChannel = trackedUsers[channelId];
         if (!usersInChannel)

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,8 +1,19 @@
 const { REST } = require("@discordjs/rest");
 const { Routes } = require("discord-api-types/v10");
 const { SlashCommandBuilder } = require("discord.js");
-// Make sure your config.json has your clientId and token!
-const { clientId, token } = require("./config.json");
+// clientId + token can come from Replit Secrets (env) or config.json. Env wins.
+let _configFile = {};
+try { _configFile = require("./config.json"); } catch { /* file optional */ }
+const clientId = process.env.DISCORD_CLIENT_ID ?? _configFile.clientId;
+const token    = process.env.DISCORD_TOKEN     ?? _configFile.token;
+if (!clientId) {
+    console.error("✗ Missing DISCORD_CLIENT_ID — set it in env or config.json.");
+    process.exit(1);
+}
+if (!token) {
+    console.error("✗ Missing DISCORD_TOKEN — set it in env or config.json.");
+    process.exit(1);
+}
 
 const commands = [
     new SlashCommandBuilder()

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,6 +1,6 @@
 const { REST } = require("@discordjs/rest");
 const { Routes } = require("discord-api-types/v10");
-const { SlashCommandBuilder } = require("discord.js");
+
 // clientId + token can come from Replit Secrets (env) or config.json. Env wins.
 let _configFile = {};
 try { _configFile = require("./config.json"); } catch { /* file optional */ }
@@ -15,78 +15,15 @@ if (!token) {
     process.exit(1);
 }
 
-const commands = [
-    new SlashCommandBuilder()
-        .setName("track")
-        .setDescription(
-            "Starts tracking an AniList user's activity in this channel.",
-        )
-        .addStringOption((option) =>
-            option
-                .setName("username")
-                .setDescription("The AniList username to track.")
-                .setRequired(true),
-        )
-        .addStringOption((option) =>
-            option
-                .setName("filter")
-                .setDescription("What type of activity to track (default: both)")
-                .setRequired(false)
-                .addChoices(
-                    { name: 'Both Anime and Manga', value: 'both' },
-                    { name: 'Anime Only', value: 'anime' },
-                    { name: 'Manga Only', value: 'manga' }
-                ),
-        ),
-
-    new SlashCommandBuilder()
-        .setName("untrack")
-        .setDescription(
-            "Stops tracking a specific AniList user in this channel.",
-        )
-        .addStringOption((option) =>
-            option
-                .setName("username")
-                .setDescription("The AniList username to stop tracking.")
-                .setRequired(true),
-        ),
-
-    new SlashCommandBuilder()
-        .setName("list")
-        .setDescription(
-            "Shows all AniList users currently being tracked in this channel.",
-        ),
-
-    new SlashCommandBuilder()
-        .setName("help")
-        .setDescription("Displays a list of all available commands."),
-
-    new SlashCommandBuilder()
-        .setName("stats")
-        .setDescription("Shows detailed statistics for an AniList user.")
-        .addStringOption((option) =>
-            option
-                .setName("username")
-                .setDescription("The AniList username to get stats for.")
-                .setRequired(true),
-        ),
-
-    new SlashCommandBuilder()
-        .setName("serverstats")
-        .setDescription("Shows statistics for all tracked users in this server."),
-].map((command) => command.toJSON());
+// Read every command's `data` block from the registry — single source of truth.
+const commands = require("./commands").map(c => c.data.toJSON());
 
 const rest = new REST({ version: "10" }).setToken(token);
 
 (async () => {
     try {
-        console.log("Started refreshing application (/) GLOBAL commands.");
-
-        // This registers the commands globally
-        await rest.put(Routes.applicationCommands(clientId), {
-            body: commands,
-        });
-
+        console.log(`Started refreshing ${commands.length} application (/) GLOBAL commands.`);
+        await rest.put(Routes.applicationCommands(clientId), { body: commands });
         console.log("Successfully reloaded application (/) GLOBAL commands.");
     } catch (error) {
         console.error(error);

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,8 +1,12 @@
+// @ts-check
 const { REST } = require("@discordjs/rest");
 const { Routes } = require("discord-api-types/v10");
 
 // clientId + token can come from Replit Secrets (env) or config.json. Env wins.
+/** @type {{ clientId?: string, token?: string }} */
 let _configFile = {};
+// @ts-ignore — config.json is gitignored, so it may not exist at type-check time;
+// the try/catch handles the runtime "missing file" case.
 try { _configFile = require("./config.json"); } catch { /* file optional */ }
 const clientId = process.env.DISCORD_CLIENT_ID ?? _configFile.clientId;
 const token    = process.env.DISCORD_TOKEN     ?? _configFile.token;

--- a/index.js
+++ b/index.js
@@ -578,6 +578,12 @@ client.on(Events.ClientReady, () => {
             console.error("Database checkpoint error:", error);
         }
     }, 1800000); // 30 minutes
+
+    // One immediate backup so a fresh deploy snapshots within seconds, then
+    // weekly thereafter. Single rotating file (overwritten in place) — coarse
+    // safety net against accidental deletion, not granular point-in-time.
+    backupDatabase();
+    setInterval(backupDatabase, 7 * 24 * 60 * 60 * 1000); // 7 days
 });
 
 // =========================================================================
@@ -1092,15 +1098,38 @@ client.on("interactionCreate", async (interaction) => {
 // =========================================================================
 
 /**
+ * Resolve the on-disk SQLite path. Replit deployments persist
+ * `$REPL_HOME/bot.db` across redeploys; locally we use `./bot.db`.
+ */
+function resolveDbPath() {
+    return process.env.REPL_HOME
+        ? path.join(process.env.REPL_HOME, 'bot.db')
+        : './bot.db';
+}
+
+/**
+ * Snapshot bot.db to bot.db.backup. Best-effort — failures log but never
+ * propagate. Coarse weekly insurance against accidental deletion or
+ * corruption; not a substitute for proper external backups.
+ */
+function backupDatabase() {
+    const dbPath = resolveDbPath();
+    try {
+        fs.copyFileSync(dbPath, dbPath + '.backup');
+        console.log("✓ Database backup written.");
+    } catch (e) {
+        console.error("Database backup failed:", e.message);
+    }
+}
+
+/**
  * Open the SQLite database (WAL mode), apply idempotent migrations,
  * hydrate the in-memory `trackedUsers` cache, and log into Discord.
  * Uses $REPL_HOME/bot.db when running on Replit, ./bot.db locally.
  */
 async function startBot() {
     try {
-        // Persistent storage on Replit so the DB survives redeploys.
-        const dbPath = process.env.REPL_HOME ?
-            path.join(process.env.REPL_HOME, 'bot.db') : './bot.db';
+        const dbPath = resolveDbPath();
 
         console.log(`Database path: ${dbPath}`);
         db = await open({ filename: dbPath, driver: sqlite3.Database });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const {
     MessageFlags,
     PermissionsBitField,
 } = require("discord.js");
-const fetch = require("node-fetch");
+// Node 20+ provides a global `fetch` — no node-fetch dep needed.
 const fs = require("fs");
 const path = require("path");
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,15 @@
 const { open } = require("sqlite");
 const sqlite3 = require("sqlite3").verbose();
 
-const { token } = require("./config.json");
+// Token can come from Replit Secrets (env) or config.json. Env wins.
+// config.json is now optional — missing file is fine if env is set.
+let _configFile = {};
+try { _configFile = require("./config.json"); } catch { /* file optional */ }
+const token = process.env.DISCORD_TOKEN ?? _configFile.token;
+if (!token) {
+    console.error("✗ Missing DISCORD_TOKEN — set it in Replit Secrets, env, or config.json.");
+    process.exit(1);
+}
 
 const {
     Client,

--- a/index.js
+++ b/index.js
@@ -110,6 +110,20 @@ const firstPollComplete = new Set();
 const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
 const PERMISSIONS_CACHE_TTL = 3600000; // 1 hour — channel perms drift slowly
 
+// AniList rate-limit gate. Updated when the API returns 429; while
+// `Date.now() < rateLimitedUntil`, every aniListFetch short-circuits.
+let rateLimitedUntil = 0;
+
+// Marker error so callers can distinguish "AniList told us to wait" from
+// generic network failures and respond with a friendly retry hint.
+class RateLimitError extends Error {
+    constructor(retryAfterMs) {
+        super(`AniList rate-limited for another ~${Math.ceil(retryAfterMs / 1000)}s`);
+        this.name = "RateLimitError";
+        this.retryAfterMs = retryAfterMs;
+    }
+}
+
 // AniList profile colors ko hex codes mein convert karne ke liye mapping
 const anilistColorMap = {
     blue: "#3DB4F2",
@@ -144,6 +158,52 @@ function getPreferredTitle(mediaTitles, preference) {
         default:
             return mediaTitles.romaji || mediaTitles.english || mediaTitles.native;
     }
+}
+
+// =========================================================================
+// AniList client
+// =========================================================================
+
+/**
+ * POST a GraphQL query to AniList with rate-limit awareness.
+ * Throws RateLimitError when we know we'd be denied (gate is active, or
+ * the response itself returns 429). On success returns the parsed JSON.
+ *
+ * AniList's per-IP limit is 90 requests/minute and is communicated via
+ * `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers.
+ */
+async function aniListFetch(query, variables) {
+    const now = Date.now();
+    if (now < rateLimitedUntil) {
+        throw new RateLimitError(rateLimitedUntil - now);
+    }
+
+    const response = await fetch("https://graphql.anilist.co", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+    });
+
+    const remainingHeader = response.headers.get("x-ratelimit-remaining");
+    const remaining = remainingHeader != null ? parseInt(remainingHeader, 10) : NaN;
+    if (Number.isFinite(remaining) && remaining < 10) {
+        console.warn(`⚠️ AniList rate limit low: ${remaining} requests remaining.`);
+    }
+
+    if (response.status === 429) {
+        const resetSec = parseInt(response.headers.get("x-ratelimit-reset") ?? "0", 10);
+        rateLimitedUntil = Number.isFinite(resetSec) && resetSec > 0
+            ? resetSec * 1000
+            : Date.now() + 60_000; // 60s fallback if header missing
+        const waitMs = rateLimitedUntil - Date.now();
+        console.warn(`⚠️ AniList returned 429. Backing off for ~${Math.ceil(waitMs / 1000)}s.`);
+        throw new RateLimitError(waitMs);
+    }
+
+    return response.json();
 }
 
 // =========================================================================
@@ -271,7 +331,6 @@ async function checkAniListActivity(channelId, anilistUserId) {
     if (!trackingInfo) return;
 
     const { anilistUsername, lastActivityId, userAvatar, userColor, titleLanguage, profileLastUpdated, activityFilter } = trackingInfo;
-    const url = "https://graphql.anilist.co";
     const filter = activityFilter || "both";
     const now = Date.now();
     const userKey = `${channelId}:${anilistUserId}`;
@@ -327,15 +386,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
 
         const variables = { userId: anilistUserId };
 
-        const response = await fetch(url, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Accept: "application/json",
-            },
-            body: JSON.stringify({ query: combinedQuery, variables }),
-        });
-        const data = await response.json();
+        const data = await aniListFetch(combinedQuery, variables);
 
         if (!data || !data.data) {
             console.error(`✗ Invalid API response for ${anilistUsername}:`, data?.errors || "Unknown error");
@@ -473,6 +524,10 @@ async function checkAniListActivity(channelId, anilistUserId) {
         // (A throw skips this line, so failed first polls re-arm themselves.)
         firstPollComplete.add(userKey);
     } catch (error) {
+        if (error.name === "RateLimitError") {
+            // Already logged at source; don't duplicate. Guard stays armed.
+            return;
+        }
         console.error(`Error fetching activity for ${anilistUsername}:`, error);
     }
 }
@@ -613,18 +668,7 @@ client.on("interactionCreate", async (interaction) => {
                     options { profileColor, titleLanguage }
                 } 
             }`;
-            const response = await fetch("https://graphql.anilist.co", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Accept: "application/json",
-                },
-                body: JSON.stringify({
-                    query: findUserQuery,
-                    variables: { username: anilistUsername },
-                }),
-            });
-            const data = await response.json();
+            const data = await aniListFetch(findUserQuery, { username: anilistUsername });
             if (!data.data || !data.data.User)
                 return interaction.editReply(
                     `Could not find an AniList user with the username **${anilistUsername}**. Please check spelling.`,
@@ -781,19 +825,7 @@ client.on("interactionCreate", async (interaction) => {
             }`;
 
             try {
-                const response = await fetch("https://graphql.anilist.co", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Accept: "application/json",
-                    },
-                    body: JSON.stringify({
-                        query: statsQuery,
-                        variables: { username: anilistUsername },
-                    }),
-                });
-
-                const data = await response.json();
+                const data = await aniListFetch(statsQuery, { username: anilistUsername });
 
                 if (!data.data || !data.data.User) {
                     return interaction.editReply(
@@ -927,22 +959,12 @@ client.on("interactionCreate", async (interaction) => {
                 }`;
 
                 try {
-                    const response = await fetch("https://graphql.anilist.co", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json",
-                            Accept: "application/json",
-                        },
-                        body: JSON.stringify({
-                            query: userQuery,
-                            variables: { id: parseInt(userId) },
-                        }),
-                    });
-
-                    const data = await response.json();
+                    const data = await aniListFetch(userQuery, { id: parseInt(userId) });
                     return data.data?.User || null;
                 } catch (error) {
-                    console.error(`Error fetching user ${userId}:`, error);
+                    if (error.name !== "RateLimitError") {
+                        console.error(`Error fetching user ${userId}:`, error);
+                    }
                     return null;
                 }
             });
@@ -952,6 +974,13 @@ client.on("interactionCreate", async (interaction) => {
                 const users = usersData.filter(u => u !== null);
 
                 if (users.length === 0) {
+                    // Distinguish rate-limit drought from genuine no-data.
+                    if (Date.now() < rateLimitedUntil) {
+                        const sec = Math.ceil((rateLimitedUntil - Date.now()) / 1000);
+                        return interaction.editReply(
+                            `AniList is temporarily rate-limiting us. Try again in ~${sec}s.`
+                        );
+                    }
                     return interaction.editReply(
                         "No data available for tracked users in this server."
                     );
@@ -1027,6 +1056,19 @@ client.on("interactionCreate", async (interaction) => {
             }
         }
     } catch (error) {
+        // RateLimitError is expected and already logged at source — give the
+        // user a clear "try again in Xs" instead of a generic failure.
+        if (error.name === "RateLimitError") {
+            const sec = Math.ceil(error.retryAfterMs / 1000);
+            try {
+                await interaction.editReply(
+                    `AniList is temporarily rate-limiting us. Try again in ~${sec}s.`,
+                );
+            } catch (e) {
+                console.error("Failed to send rate-limit reply:", e.message);
+            }
+            return;
+        }
         console.error(
             `An error occurred while executing the /${commandName} command:`,
             error,

--- a/index.js
+++ b/index.js
@@ -721,8 +721,13 @@ client.on("interactionCreate", async (interaction) => {
                     `✓ Successfully deleted ${userToUntrackInfo.anilistUsername} from database (verified).`,
                 );
                 delete trackedUsers[channelId][userIdToUntrack];
-                if (Object.keys(trackedUsers[channelId]).length === 0)
+                if (Object.keys(trackedUsers[channelId]).length === 0) {
                     delete trackedUsers[channelId];
+                    // Channel ab khaali hai — per-channel caches bhi drop kar do
+                    // taake long-running deploys mein stale entries jama na hon.
+                    delete webhookCache[channelId];
+                    delete permissionsCache[channelId];
+                }
                 await interaction.editReply(
                     `Stopped tracking **${userToUntrackInfo.anilistUsername}** in this channel.`,
                 );

--- a/index.js
+++ b/index.js
@@ -2,10 +2,8 @@
 const { open } = require("sqlite");
 const sqlite3 = require("sqlite3").verbose();
 
-// config file se token import karna
 const { token } = require("./config.json");
 
-// discord.js ke zaroori classes
 const {
     Client,
     GatewayIntentBits,
@@ -17,61 +15,68 @@ const fetch = require("node-fetch");
 const fs = require("fs");
 const path = require("path");
 
-// Lock file to prevent multiple instances - use persistent storage
-const LOCK_FILE = process.env.REPL_HOME ? 
-    path.join(process.env.REPL_HOME, 'bot.lock') : 
+// =========================================================================
+// Single-instance lock
+// =========================================================================
+
+// Lock file persistent storage path par rakhte hain (Replit deployments survive redeploys).
+const LOCK_FILE = process.env.REPL_HOME ?
+    path.join(process.env.REPL_HOME, 'bot.lock') :
     path.join(__dirname, 'bot.lock');
 
-// Check if another instance is running
+/**
+ * Acquire a process-wide lock at LOCK_FILE so only one bot instance runs.
+ * If a live PID already owns the lock, exits with code 1.
+ * Stale locks (PID no longer alive) are cleared and re-acquired.
+ * Wires `exit`, `SIGINT`, `SIGTERM`, and `SIGQUIT` to clean up the lock.
+ */
 function checkSingleInstance() {
     try {
         if (fs.existsSync(LOCK_FILE)) {
             const lockPid = fs.readFileSync(LOCK_FILE, 'utf8');
             try {
-                // Check if that process is still running
+                // Signal 0 = "is the process alive?" without actually killing it.
                 process.kill(lockPid, 0);
                 console.error(`❌ Another instance is already running (PID: ${lockPid}). Exiting...`);
                 process.exit(1);
             } catch (e) {
-                // Process doesn't exist, remove stale lock file
+                // Process gone, lock file stale — clear it and continue.
                 console.log('🔧 Removing stale lock file...');
                 fs.unlinkSync(LOCK_FILE);
             }
         }
-        
-        // Create lock file with current PID
+
         fs.writeFileSync(LOCK_FILE, process.pid.toString());
         console.log(`✓ Lock acquired (PID: ${process.pid})`);
-        
-        // Clean up lock file on exit
+
         process.on('exit', () => {
             try {
                 fs.unlinkSync(LOCK_FILE);
             } catch (e) {
-                // Ignore errors on cleanup
+                // Cleanup-only path; swallow errors.
             }
         });
-        
-        // Handle termination signals
+
         ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(signal => {
             process.on(signal, () => {
                 console.log(`\n${signal} received, cleaning up...`);
                 try {
                     fs.unlinkSync(LOCK_FILE);
                 } catch (e) {
-                    // Ignore errors
+                    // Cleanup-only path; swallow errors.
                 }
                 process.exit(0);
             });
         });
-        
+
     } catch (error) {
         console.error('Error setting up single instance lock:', error);
         process.exit(1);
     }
 }
 
-// Call this immediately to prevent multiple instances
+// Lock acquisition is at top-level (not inside startBot) so it runs before
+// any other module-level work and rejects double-spawns immediately.
 checkSingleInstance();
 
 // agar koi promise reject ho jaye to bot crash na ho
@@ -80,10 +85,14 @@ process.on("unhandledRejection", (error) => {
     // error log kar dete hain lekin bot ko crash nahi karte
 });
 
+// =========================================================================
+// Globals & Discord client
+// =========================================================================
+
 let trackedUsers = {}; // memory mein users ka data rakhe ga
 let db; // database ka instance
-let webhookCache = {}; // cache webhooks per channel
-const PROFILE_CACHE_DURATION = 86400000; // 24 hours in milliseconds
+let webhookCache = {}; // channelId -> Webhook
+const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
 
 // AniList profile colors ko hex codes mein convert karne ke liye mapping
 const anilistColorMap = {
@@ -96,12 +105,18 @@ const anilistColorMap = {
     gray: "#677B94",
 };
 
-// discord client banate hain
 const client = new Client({
     intents: [GatewayIntentBits.Guilds],
 });
 
-// Helper function to get the correct title based on user preference
+// =========================================================================
+// Helpers
+// =========================================================================
+
+/**
+ * Pick the title field that matches the user's AniList language preference.
+ * Falls back through romaji → english → native if the requested field is empty.
+ */
 function getPreferredTitle(mediaTitles, preference) {
     switch (preference) {
         case "ENGLISH":
@@ -115,33 +130,36 @@ function getPreferredTitle(mediaTitles, preference) {
     }
 }
 
-// Webhook management functions
+// =========================================================================
+// Webhook delivery
+// =========================================================================
+
+/**
+ * Return a cached or freshly created "AniList Activity" webhook for the given channel.
+ * Returns null if the bot lacks MANAGE_WEBHOOKS in the channel, or if creation/fetch fails.
+ * Cached webhooks are revalidated on each call; deleted webhooks are evicted automatically.
+ */
 async function getOrCreateWebhook(channel) {
-    // Check cache first
     if (webhookCache[channel.id]) {
         try {
-            // Verify webhook still exists
+            // Revalidate — webhook may have been deleted out from under us.
             await webhookCache[channel.id].fetch();
             return webhookCache[channel.id];
         } catch (error) {
-            // Webhook was deleted, remove from cache
             delete webhookCache[channel.id];
         }
     }
-    
+
     try {
-        // Check bot permissions
         const permissions = channel.permissionsFor(client.user);
         if (!permissions.has(PermissionsBitField.Flags.ManageWebhooks)) {
             console.warn(`⚠️ Missing MANAGE_WEBHOOKS permission in channel ${channel.id}`);
             return null;
         }
-        
-        // Fetch existing webhooks
+
         const webhooks = await channel.fetchWebhooks();
         let webhook = webhooks.find(wh => wh.owner?.id === client.user.id && wh.name === 'AniList Activity');
-        
-        // Create if doesn't exist
+
         if (!webhook) {
             webhook = await channel.createWebhook({
                 name: 'AniList Activity',
@@ -149,8 +167,7 @@ async function getOrCreateWebhook(channel) {
             });
             console.log(`✓ Created webhook for channel ${channel.id}`);
         }
-        
-        // Cache it
+
         webhookCache[channel.id] = webhook;
         return webhook;
     } catch (error) {
@@ -159,38 +176,41 @@ async function getOrCreateWebhook(channel) {
     }
 }
 
-// Send activity via webhook or fallback to regular message
+/**
+ * Send an activity embed to a channel.
+ * Prefers webhook delivery (so the post wears the AniList user's name/avatar);
+ * falls back to a regular bot message if the webhook is missing or fails.
+ * Returns true if the post went through a webhook, false if it fell back.
+ */
 async function sendActivityUpdate(channel, anilistUsername, userAvatar, embed) {
     let messageSent = false;
-    
+
     try {
         const webhook = await getOrCreateWebhook(channel);
-        
+
         if (webhook) {
-            // Try to send via webhook with user's identity
             try {
                 await webhook.send({
                     username: anilistUsername,
                     avatarURL: userAvatar || undefined,
                     embeds: [embed],
                 });
-                return true; // Successfully sent via webhook
+                return true;
             } catch (webhookError) {
                 console.error(`Webhook send failed, falling back to regular message:`, webhookError.message);
-                // Remove broken webhook from cache
                 delete webhookCache[channel.id];
-                // Fall through to send regular message
+                // Fall through to the plain channel.send below.
             }
         }
-        
-        // Send regular message (either no webhook or webhook failed)
-        messageSent = true; // Mark that we're attempting a send
+
+        // No webhook (or webhook send failed) — send as the bot.
+        messageSent = true; // mark before send, so the catch below knows we already tried
         await channel.send({ embeds: [embed] });
-        return false; // Sent via regular message
-        
+        return false;
+
     } catch (error) {
         console.error(`Error in sendActivityUpdate:`, error.message);
-        // Only retry if we haven't already attempted to send a regular message
+        // Only retry if the regular-message branch hasn't been attempted yet.
         if (!messageSent) {
             try {
                 await channel.send({ embeds: [embed] });
@@ -202,7 +222,20 @@ async function sendActivityUpdate(channel, anilistUsername, userAvatar, embed) {
     }
 }
 
-// AniList activity check karne ka function
+// =========================================================================
+// AniList polling
+// =========================================================================
+
+/**
+ * Poll AniList for one tracked (channelId, anilistUserId) pair and post any new
+ * list activity to the channel. Builds a single combined GraphQL query that also
+ * refreshes profile data (avatar, color, title language) once per PROFILE_CACHE_DURATION.
+ *
+ * Posts at most 15 activities per call (oldest first), filtered by the user's
+ * anime/manga/both preference. Always advances lastActivityId to the newest
+ * fetched activity even if the filter dropped it, so filtered-out items aren't
+ * re-evaluated next tick.
+ */
 async function checkAniListActivity(channelId, anilistUserId) {
     const trackingInfo = trackedUsers[channelId]?.[anilistUserId];
     if (!trackingInfo) return;
@@ -211,16 +244,17 @@ async function checkAniListActivity(channelId, anilistUserId) {
     const url = "https://graphql.anilist.co";
     const filter = activityFilter || "both";
     const now = Date.now();
-    
-    // Check if we need to refresh profile data (older than 24 hours or missing)
+
+    // Profile data 24h baad refresh karte hain — saves ~98% of profile-only API calls.
     const needsProfileRefresh = !profileLastUpdated || (now - profileLastUpdated) > PROFILE_CACHE_DURATION;
 
     try {
         let currentAvatar = userAvatar;
         let currentColor = userColor;
         let currentTitleLanguage = titleLanguage || "ROMAJI";
-        
-        // Combined query: Fetch both user profile (if needed) and activities in ONE request
+
+        // Combined query: profile + activities in ONE request when refresh is due,
+        // activities-only otherwise.
         const combinedQuery = needsProfileRefresh
             ? `query ($userId: Int) { 
                 User(id: $userId) { 
@@ -258,10 +292,9 @@ async function checkAniListActivity(channelId, anilistUserId) {
                     } 
                 }
             }`;
-        
+
         const variables = { userId: anilistUserId };
-        
-        // Single API call for everything
+
         const response = await fetch(url, {
             method: "POST",
             headers: {
@@ -271,37 +304,33 @@ async function checkAniListActivity(channelId, anilistUserId) {
             body: JSON.stringify({ query: combinedQuery, variables }),
         });
         const data = await response.json();
-        
-        // Validate API response
+
         if (!data || !data.data) {
             console.error(`✗ Invalid API response for ${anilistUsername}:`, data?.errors || "Unknown error");
             return;
         }
-        
-        // Update profile data if we fetched it
+
         if (needsProfileRefresh && data.data?.User) {
             currentAvatar = data.data.User.avatar?.large;
             currentColor = data.data.User.options?.profileColor;
             currentTitleLanguage = data.data.User.options?.titleLanguage || "ROMAJI";
-            
-            // Update database with new profile data
+
             await db.run(
                 `UPDATE tracked_users SET userAvatar = ?, userColor = ?, titleLanguage = ?, profileLastUpdated = ? WHERE channelId = ? AND anilistUserId = ?`,
                 [currentAvatar, currentColor, currentTitleLanguage, now, channelId, anilistUserId]
             );
-            
-            // Checkpoint to persist profile updates
+
+            // Checkpoint so a sudden kill doesn't lose the profile refresh.
             await db.exec("PRAGMA wal_checkpoint(PASSIVE);");
-            
-            // Update memory cache
+
             trackedUsers[channelId][anilistUserId].userAvatar = currentAvatar;
             trackedUsers[channelId][anilistUserId].userColor = currentColor;
             trackedUsers[channelId][anilistUserId].titleLanguage = currentTitleLanguage;
             trackedUsers[channelId][anilistUserId].profileLastUpdated = now;
-            
+
             console.log(`✓ Refreshed profile data for ${anilistUsername}`);
         }
-        
+
         const activityData = data.data;
 
         if (
@@ -310,24 +339,25 @@ async function checkAniListActivity(channelId, anilistUserId) {
         ) {
             const activities = activityData.Page.activities;
 
-            // Find all new activities (those with ID greater than lastActivityId)
+            // Naye activities = jin ki id last seen se badi hai.
+            // Pehli baar (`lastActivityId == null`) sirf latest ek hi post karte hain
+            // taake pura backlog flood na ho.
             let newActivities = lastActivityId
                 ? activities.filter((activity) => activity.id > lastActivityId)
-                : [activities[0]]; // If no lastActivityId, only show the most recent one
+                : [activities[0]];
 
-            // Apply activity filter based on user preference
             if (filter === 'anime') {
                 newActivities = newActivities.filter(activity => activity.media.type === 'ANIME');
             } else if (filter === 'manga') {
                 newActivities = newActivities.filter(activity => activity.media.type === 'MANGA');
             }
-            // If 'both', show everything (no filter)
+            // 'both' => no filter
 
             if (newActivities.length > 0) {
-                // Cap at 15 activities to prevent spam, but still update to latest
+                // 15 ka cap so a long absence can't dump 50 posts at once.
                 const activitiesToShow = newActivities.slice(0, 15);
                 const skippedCount = newActivities.length - activitiesToShow.length;
-                
+
                 console.log(
                     `${newActivities.length} new activity/activities for ${anilistUsername}` +
                     (skippedCount > 0 ? ` (showing ${activitiesToShow.length}, skipping ${skippedCount} older ones)` : ''),
@@ -335,20 +365,18 @@ async function checkAniListActivity(channelId, anilistUserId) {
                 const channel = await client.channels.fetch(channelId);
 
                 if (channel) {
-                    // Sort activities oldest to newest for posting
+                    // Post oldest-first so the channel reads chronologically.
                     activitiesToShow.reverse();
 
-                    // Determine embed color (use profile color or default)
-                    const embedColor = currentColor 
+                    const embedColor = currentColor
                         ? (anilistColorMap[currentColor.toLowerCase()] || "#C3B1E1")
                         : "#C3B1E1";
-                    
+
                     for (const activity of activitiesToShow) {
                         const mediaTitle = getPreferredTitle(activity.media.title, currentTitleLanguage);
-                        
-                        // Build description
+
                         const description = `${activity.status} ${activity.progress || ""} - **[${mediaTitle}](${activity.media.siteUrl})**`;
-                        
+
                         const embed = new EmbedBuilder()
                             .setColor(embedColor)
                             .setAuthor({
@@ -359,17 +387,17 @@ async function checkAniListActivity(channelId, anilistUserId) {
                             .setDescription(description)
                             .setThumbnail(activity.media.coverImage.large)
                             .setTimestamp(activity.createdAt * 1000)
-                            .setFooter({ 
-                                text: "Asterism • From AniList", 
-                                iconURL: client.user.displayAvatarURL() 
+                            .setFooter({
+                                text: "Asterism • From AniList",
+                                iconURL: client.user.displayAvatarURL()
                             });
-                        
-                        // Send via webhook (user's name and avatar will appear as the author)
+
                         await sendActivityUpdate(channel, anilistUsername, currentAvatar, embed);
                     }
                 }
 
-                // Update to the most recent activity ID
+                // Watermark advances to the newest fetched activity (even if filter
+                // dropped it) so we never re-evaluate the same items.
                 const mostRecentActivityId = activities[0].id;
                 const sql = `UPDATE tracked_users SET lastActivityId = ? WHERE channelId = ? AND anilistUserId = ?`;
                 await db.run(sql, [
@@ -377,16 +405,15 @@ async function checkAniListActivity(channelId, anilistUserId) {
                     channelId,
                     anilistUserId,
                 ]);
-                
-                // Force checkpoint to ensure data is persisted
+
                 await db.exec("PRAGMA wal_checkpoint(PASSIVE);");
-                
-                // Verify the write was successful
+
+                // Read-back verification — DB write must stick before we trust memory.
                 const verification = await db.get(
                     `SELECT lastActivityId FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
                     [channelId, anilistUserId]
                 );
-                
+
                 if (verification && verification.lastActivityId === mostRecentActivityId) {
                     trackedUsers[channelId][anilistUserId].lastActivityId =
                         mostRecentActivityId;
@@ -405,28 +432,31 @@ async function checkAniListActivity(channelId, anilistUserId) {
     }
 }
 
-// bot ready hone par
+// =========================================================================
+// Ready handler — initial check + intervals
+// =========================================================================
+
 client.on("ready", () => {
     console.log(`Logged in as ${client.user.tag}!`);
-    
-    // Set custom status
+
     client.user.setActivity('/help');
-    
-    // Immediately check once on startup
+
+    // Immediate startup check so newly redeployed bots don't wait 10 minutes
+    // before posting.
     const userCount = Object.keys(trackedUsers).reduce((total, channelId) => {
         return total + Object.keys(trackedUsers[channelId]).length;
     }, 0);
-    
+
     console.log(`Checking for new AniList activity (initial check)... Found ${userCount} tracked users.`);
-    
+
     for (const channelId in trackedUsers) {
         for (const anilistUserId in trackedUsers[channelId]) {
             console.log(`Initial check: ${trackedUsers[channelId][anilistUserId].anilistUsername}`);
             checkAniListActivity(channelId, anilistUserId);
         }
     }
-    
-    // Then set up the interval for regular checks
+
+    // har 10 minute mein check karte hain
     setInterval(() => {
         console.log("Checking for new AniList activity...");
         for (const channelId in trackedUsers) {
@@ -434,9 +464,9 @@ client.on("ready", () => {
                 checkAniListActivity(channelId, anilistUserId);
             }
         }
-    }, 600000); // har 10 minute mein check karte hain
-    
-    // Periodic database checkpoint every 30 minutes to ensure persistence
+    }, 600000);
+
+    // Periodic checkpoint so WAL doesn't grow unbounded between writes.
     setInterval(async () => {
         try {
             await db.exec("PRAGMA wal_checkpoint(PASSIVE);");
@@ -447,13 +477,16 @@ client.on("ready", () => {
     }, 1800000); // 30 minutes
 });
 
-// slash commands handle karte hain
+// =========================================================================
+// Slash command dispatcher
+// =========================================================================
+
 client.on("interactionCreate", async (interaction) => {
     if (!interaction.isChatInputCommand()) return;
     const { commandName } = interaction;
 
     try {
-        // ephemeral replies ke liye flags use karte hain
+        // /list, /help, /untrack are management — keep them ephemeral.
         await interaction.deferReply({
             flags: ["list", "help", "untrack"].includes(commandName)
                 ? [MessageFlags.Ephemeral]
@@ -507,7 +540,7 @@ client.on("interactionCreate", async (interaction) => {
                         .map((user) => {
                             const filterEmoji = user.activityFilter === 'anime' ? '📺' :
                                               user.activityFilter === 'manga' ? '📖' : '📺📖';
-                            const filterText = user.activityFilter === 'both' ? '' : 
+                            const filterText = user.activityFilter === 'both' ? '' :
                                              ` (${user.activityFilter} only)`;
                             return `• ${filterEmoji} **${user.anilistUsername}**${filterText}`;
                         })
@@ -523,8 +556,8 @@ client.on("interactionCreate", async (interaction) => {
             const anilistUsername = interaction.options.getString("username");
             const activityFilter = interaction.options.getString("filter") || "both";
             const channelId = interaction.channelId;
-            
-            // Fetch user ID and profile data in one query
+
+            // Lookup ID + profile (avatar/color/titleLanguage) in a single query.
             const findUserQuery = `query ($username: String) { 
                 User(name: $username) { 
                     id 
@@ -548,18 +581,18 @@ client.on("interactionCreate", async (interaction) => {
                 return interaction.editReply(
                     `Could not find an AniList user with the username **${anilistUsername}**. Please check spelling.`,
                 );
-            
+
             const anilistUserId = data.data.User.id;
             const userAvatar = data.data.User.avatar?.large;
             const userColor = data.data.User.options?.profileColor;
             const titleLanguage = data.data.User.options?.titleLanguage || "ROMAJI";
             const now = Date.now();
-            
+
             if (trackedUsers[channelId]?.[anilistUserId])
                 return interaction.editReply(
                     `**${anilistUsername}** is already being tracked in this channel.`,
                 );
-            
+
             const sql = `INSERT INTO tracked_users (channelId, anilistUsername, anilistUserId, lastActivityId, userAvatar, userColor, titleLanguage, profileLastUpdated, activityFilter) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
             await db.run(sql, [
                 channelId,
@@ -572,16 +605,15 @@ client.on("interactionCreate", async (interaction) => {
                 now,
                 activityFilter,
             ]);
-            
-            // Force checkpoint to ensure data is persisted to main database file
+
+            // FULL checkpoint — user-facing write, must survive a kill.
             await db.exec("PRAGMA wal_checkpoint(FULL);");
-            
-            // Verify the insert was successful
+
             const verification = await db.get(
                 `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
                 [channelId, anilistUserId]
             );
-            
+
             if (verification) {
                 console.log(
                     `✓ [SUCCESS] Database write for ${anilistUsername} completed and verified.`,
@@ -602,7 +634,7 @@ client.on("interactionCreate", async (interaction) => {
                 );
                 throw new Error("Failed to persist user to database");
             }
-            const filterText = activityFilter === 'both' ? 'all activity' : 
+            const filterText = activityFilter === 'both' ? 'all activity' :
                               activityFilter === 'anime' ? 'anime only' : 'manga only';
             await interaction.editReply(
                 `Successfully found **${anilistUsername}**. Now tracking their ${filterText} in this channel!`,
@@ -635,16 +667,15 @@ client.on("interactionCreate", async (interaction) => {
                 });
             const sql = `DELETE FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`;
             await db.run(sql, [channelId, userIdToUntrack]);
-            
-            // Force checkpoint to ensure deletion is persisted
+
+            // FULL checkpoint — user-facing write, must survive a kill.
             await db.exec("PRAGMA wal_checkpoint(FULL);");
-            
-            // Verify the delete was successful
+
             const verification = await db.get(
                 `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
                 [channelId, userIdToUntrack]
             );
-            
+
             if (!verification) {
                 console.log(
                     `✓ Successfully deleted ${userToUntrackInfo.anilistUsername} from database (verified).`,
@@ -665,8 +696,7 @@ client.on("interactionCreate", async (interaction) => {
             }
         } else if (commandName === "stats") {
             const anilistUsername = interaction.options.getString("username");
-            
-            // Fetch comprehensive user statistics
+
             const statsQuery = `query ($username: String) {
                 User(name: $username) {
                     id
@@ -696,7 +726,7 @@ client.on("interactionCreate", async (interaction) => {
                     }
                 }
             }`;
-            
+
             try {
                 const response = await fetch("https://graphql.anilist.co", {
                     method: "POST",
@@ -709,37 +739,33 @@ client.on("interactionCreate", async (interaction) => {
                         variables: { username: anilistUsername },
                     }),
                 });
-                
+
                 const data = await response.json();
-                
+
                 if (!data.data || !data.data.User) {
                     return interaction.editReply(
                         `Could not find an AniList user with the username **${anilistUsername}**.`
                     );
                 }
-                
+
                 const user = data.data.User;
                 const animeStats = user.statistics.anime;
                 const mangaStats = user.statistics.manga;
-                
-                // Calculate days watched
+
                 const daysWatched = (animeStats.minutesWatched / 1440).toFixed(1);
-                
-                // Get favorite anime (top 3)
+
                 const favAnime = user.favourites.anime.nodes
                     .slice(0, 3)
                     .map(a => a.title.romaji)
                     .join(", ") || "None";
-                
-                // Get favorite manga (top 3)
+
                 const favManga = user.favourites.manga.nodes
                     .slice(0, 3)
                     .map(m => m.title.romaji)
                     .join(", ") || "None";
-                
-                // Get favorite character
+
                 const favChar = user.favourites.characters.nodes[0]?.name.full || "None";
-                
+
                 const statsEmbed = new EmbedBuilder()
                     .setColor("#C3B1E1")
                     .setAuthor({
@@ -777,11 +803,11 @@ client.on("interactionCreate", async (interaction) => {
                             ].join("\n"),
                         }
                     );
-                
+
                 if (user.bannerImage) {
                     statsEmbed.setImage(user.bannerImage);
                 }
-                
+
                 await interaction.editReply({ embeds: [statsEmbed] });
             } catch (error) {
                 console.error(`Error fetching stats for ${anilistUsername}:`, error);
@@ -790,12 +816,12 @@ client.on("interactionCreate", async (interaction) => {
                 );
             }
         } else if (commandName === "serverstats") {
-            // Collect all unique users tracked in this server (across all channels)
+            // Collect every unique AniList user tracked anywhere in this guild
+            // (a user may be tracked in multiple channels — dedupe by AniList ID).
             const guildId = interaction.guildId;
             const allChannelsInGuild = Object.keys(trackedUsers);
             const uniqueUsers = new Map();
-            
-            // Gather all unique tracked users in this guild
+
             for (const channelId of allChannelsInGuild) {
                 try {
                     const channel = await client.channels.fetch(channelId);
@@ -808,22 +834,22 @@ client.on("interactionCreate", async (interaction) => {
                         }
                     }
                 } catch (error) {
-                    // Channel might not be accessible, skip it
+                    // Channel inaccessible — skip silently and continue.
                     continue;
                 }
             }
-            
+
             if (uniqueUsers.size === 0) {
                 return interaction.editReply(
                     "No users are currently being tracked in this server."
                 );
             }
-            
-            // Fetch statistics for all tracked users individually
+
             const userIds = Array.from(uniqueUsers.keys());
             console.log(`Fetching server stats for ${userIds.length} users:`, userIds);
-            
-            // We need to fetch each user individually since batch query doesn't work
+
+            // AniList's schema doesn't expose a multi-User field, so we fan out
+            // one query per user and Promise.all the lot.
             const userDataPromises = userIds.map(async (userId) => {
                 const userQuery = `query ($id: Int) {
                     User(id: $id) {
@@ -846,7 +872,7 @@ client.on("interactionCreate", async (interaction) => {
                         }
                     }
                 }`;
-                
+
                 try {
                     const response = await fetch("https://graphql.anilist.co", {
                         method: "POST",
@@ -859,7 +885,7 @@ client.on("interactionCreate", async (interaction) => {
                             variables: { id: parseInt(userId) },
                         }),
                     });
-                    
+
                     const data = await response.json();
                     return data.data?.User || null;
                 } catch (error) {
@@ -867,25 +893,24 @@ client.on("interactionCreate", async (interaction) => {
                     return null;
                 }
             });
-            
+
             try {
                 const usersData = await Promise.all(userDataPromises);
                 const users = usersData.filter(u => u !== null);
-                
+
                 if (users.length === 0) {
                     return interaction.editReply(
                         "No data available for tracked users in this server."
                     );
                 }
-                
-                // Calculate aggregate statistics
+
                 let totalAnime = 0;
                 let totalEpisodes = 0;
                 let totalManga = 0;
                 let totalChapters = 0;
                 let totalMinutes = 0;
                 let avgScore = 0;
-                
+
                 users.forEach(user => {
                     totalAnime += user.statistics.anime.count;
                     totalEpisodes += user.statistics.anime.episodesWatched;
@@ -894,11 +919,10 @@ client.on("interactionCreate", async (interaction) => {
                     totalMinutes += user.statistics.anime.minutesWatched;
                     avgScore += user.statistics.anime.meanScore;
                 });
-                
+
                 avgScore = (avgScore / users.length).toFixed(1);
                 const totalDays = (totalMinutes / 1440).toFixed(1);
-                
-                // Find top watchers
+
                 const topWatchers = users
                     .sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)
                     .slice(0, 5)
@@ -907,10 +931,9 @@ client.on("interactionCreate", async (interaction) => {
                         return `${i + 1}. ${avatarEmoji} **[${u.name}](https://anilist.co/user/${u.name})** - ${u.statistics.anime.count} anime`;
                     })
                     .join("\n");
-                
-                // Get top user's avatar for thumbnail
+
                 const topUser = users.sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)[0];
-                
+
                 const serverStatsEmbed = new EmbedBuilder()
                     .setColor("#C3B1E1")
                     .setTitle(`📊 Server AniList Statistics`)
@@ -941,7 +964,7 @@ client.on("interactionCreate", async (interaction) => {
                     )
                     .setThumbnail(topUser?.avatar?.medium || null)
                     .setTimestamp();
-                
+
                 await interaction.editReply({ embeds: [serverStatsEmbed] });
             } catch (error) {
                 console.error("Error fetching server stats:", error.message, error.stack);
@@ -969,20 +992,28 @@ client.on("interactionCreate", async (interaction) => {
     }
 });
 
-// bot ko start karne ka main function
+// =========================================================================
+// Startup — database open, migrations, hydration, login
+// =========================================================================
+
+/**
+ * Open the SQLite database (WAL mode), apply idempotent migrations,
+ * hydrate the in-memory `trackedUsers` cache, and log into Discord.
+ * Uses $REPL_HOME/bot.db when running on Replit, ./bot.db locally.
+ */
 async function startBot() {
     try {
-        // Use persistent storage path for Replit deployments
-        const dbPath = process.env.REPL_HOME ? 
+        // Persistent storage on Replit so the DB survives redeploys.
+        const dbPath = process.env.REPL_HOME ?
             path.join(process.env.REPL_HOME, 'bot.db') : './bot.db';
-        
+
         console.log(`Database path: ${dbPath}`);
         db = await open({ filename: dbPath, driver: sqlite3.Database });
         console.log("Connected to the SQLite database.");
-        
-        // Enable WAL mode for better concurrent access and prevent corruption
+
+        // WAL mode = better concurrent reads + crash resistance.
         await db.exec("PRAGMA journal_mode = WAL;");
-        
+
         await db.exec(
             `CREATE TABLE IF NOT EXISTS tracked_users (
                 channelId TEXT NOT NULL, 
@@ -998,11 +1029,11 @@ async function startBot() {
             )`,
         );
         console.log("tracked_users table is ready.");
-        
-        // Migration: Add new columns if they don't exist (for existing databases)
+
+        // Idempotent migrations — `ADD COLUMN` only when not already present.
         const tableInfo = await db.all("PRAGMA table_info(tracked_users)");
         const columnNames = tableInfo.map(col => col.name);
-        
+
         if (!columnNames.includes('userAvatar')) {
             await db.exec(`ALTER TABLE tracked_users ADD COLUMN userAvatar TEXT`);
             console.log("✓ Added userAvatar column");
@@ -1023,15 +1054,14 @@ async function startBot() {
             await db.exec(`ALTER TABLE tracked_users ADD COLUMN activityFilter TEXT DEFAULT 'both'`);
             console.log("✓ Added activityFilter column");
         }
-        
-        // Checkpoint after migration
+
         await db.exec("PRAGMA wal_checkpoint(FULL);");
-        
-        // Load data from database with detailed logging
+
+        // Hydrate trackedUsers cache from disk.
         const rows = await db.all("SELECT * FROM tracked_users");
         console.log(`\n=== DATABASE LOAD START ===`);
         console.log(`Found ${rows.length} tracked entries in database.`);
-        
+
         rows.forEach((row, index) => {
             if (!trackedUsers[row.channelId]) trackedUsers[row.channelId] = {};
             trackedUsers[row.channelId][row.anilistUserId] = {
@@ -1045,7 +1075,7 @@ async function startBot() {
             };
             console.log(`  [${index + 1}] User: ${row.anilistUsername} (ID: ${row.anilistUserId}), LastActivityId: ${row.lastActivityId}, Channel: ${row.channelId}`);
         });
-        
+
         console.log(`=== DATABASE LOAD COMPLETE ===\n`);
         console.log("Database loaded. Logging into Discord...");
         client.login(token);
@@ -1055,25 +1085,30 @@ async function startBot() {
     }
 }
 
-// Graceful shutdown handling to ensure database persists
+// =========================================================================
+// Graceful shutdown
+// =========================================================================
+
+/**
+ * Final WAL checkpoint, close the database, and remove the lock file.
+ * Wired to SIGHUP only — SIGINT/SIGTERM/SIGQUIT are handled in checkSingleInstance().
+ */
 async function gracefulShutdown(signal) {
     console.log(`\n${signal} received. Closing database and shutting down gracefully...`);
     try {
-        // Final checkpoint to flush all changes to main database file
         if (db) {
             await db.exec("PRAGMA wal_checkpoint(FULL);");
             await db.close();
             console.log("✓ Database closed successfully.");
         }
-        
-        // Remove lock file
+
         try {
             fs.unlinkSync(LOCK_FILE);
             console.log("✓ Lock file removed.");
         } catch (e) {
-            // Ignore if lock file doesn't exist
+            // Lock already gone — ignore.
         }
-        
+
         process.exit(0);
     } catch (error) {
         console.error("Error during shutdown:", error);
@@ -1081,7 +1116,6 @@ async function gracefulShutdown(signal) {
     }
 }
 
-// Handle SIGHUP separately (other signals handled in checkSingleInstance)
 process.on('SIGHUP', () => gracefulShutdown('SIGHUP'));
 
 // bot shuru karte hain

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const { token } = require("./config.json");
 
 const {
     Client,
+    Events,
     GatewayIntentBits,
     EmbedBuilder,
     MessageFlags,
@@ -92,7 +93,9 @@ process.on("unhandledRejection", (error) => {
 let trackedUsers = {}; // memory mein users ka data rakhe ga
 let db; // database ka instance
 let webhookCache = {}; // channelId -> Webhook
+let permissionsCache = {}; // channelId -> { hasManageWebhooks, expiresAt }
 const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
+const PERMISSIONS_CACHE_TTL = 3600000; // 1 hour — channel perms drift slowly
 
 // AniList profile colors ko hex codes mein convert karne ke liye mapping
 const anilistColorMap = {
@@ -151,8 +154,22 @@ async function getOrCreateWebhook(channel) {
     }
 
     try {
-        const permissions = channel.permissionsFor(client.user);
-        if (!permissions.has(PermissionsBitField.Flags.ManageWebhooks)) {
+        // Permissions check is cached per channel to avoid recomputing role math
+        // on every poll. 1 hour TTL — perms changes lag a tick at most.
+        const now = Date.now();
+        const cached = permissionsCache[channel.id];
+        let hasManageWebhooks;
+        if (cached && cached.expiresAt > now) {
+            hasManageWebhooks = cached.hasManageWebhooks;
+        } else {
+            hasManageWebhooks = channel.permissionsFor(client.user)
+                .has(PermissionsBitField.Flags.ManageWebhooks);
+            permissionsCache[channel.id] = {
+                hasManageWebhooks,
+                expiresAt: now + PERMISSIONS_CACHE_TTL,
+            };
+        }
+        if (!hasManageWebhooks) {
             console.warn(`⚠️ Missing MANAGE_WEBHOOKS permission in channel ${channel.id}`);
             return null;
         }
@@ -261,7 +278,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
                     avatar { large }, 
                     options { profileColor, titleLanguage } 
                 }
-                Page(page: 1, perPage: 50) { 
+                Page(page: 1, perPage: 20) { 
                     activities(userId: $userId, sort: ID_DESC, type: MEDIA_LIST) { 
                         ... on ListActivity { 
                             id status progress createdAt 
@@ -277,7 +294,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
                 }
             }`
             : `query ($userId: Int) { 
-                Page(page: 1, perPage: 50) { 
+                Page(page: 1, perPage: 20) { 
                     activities(userId: $userId, sort: ID_DESC, type: MEDIA_LIST) { 
                         ... on ListActivity { 
                             id status progress createdAt 
@@ -320,9 +337,8 @@ async function checkAniListActivity(channelId, anilistUserId) {
                 [currentAvatar, currentColor, currentTitleLanguage, now, channelId, anilistUserId]
             );
 
-            // Checkpoint so a sudden kill doesn't lose the profile refresh.
-            await db.exec("PRAGMA wal_checkpoint(PASSIVE);");
-
+            // No checkpoint here — synchronous=NORMAL fsyncs at commit, and the
+            // 30-minute periodic checkpoint folds WAL into the main DB file.
             trackedUsers[channelId][anilistUserId].userAvatar = currentAvatar;
             trackedUsers[channelId][anilistUserId].userColor = currentColor;
             trackedUsers[channelId][anilistUserId].titleLanguage = currentTitleLanguage;
@@ -406,8 +422,6 @@ async function checkAniListActivity(channelId, anilistUserId) {
                     anilistUserId,
                 ]);
 
-                await db.exec("PRAGMA wal_checkpoint(PASSIVE);");
-
                 // Read-back verification — DB write must stick before we trust memory.
                 const verification = await db.get(
                     `SELECT lastActivityId FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
@@ -436,7 +450,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
 // Ready handler — initial check + intervals
 // =========================================================================
 
-client.on("ready", () => {
+client.on(Events.ClientReady, () => {
     console.log(`Logged in as ${client.user.tag}!`);
 
     client.user.setActivity('/help');
@@ -458,6 +472,9 @@ client.on("ready", () => {
 
     // har 10 minute mein check karte hain
     setInterval(() => {
+        // No tracked users → no work, no log line, no wakeup cost.
+        if (Object.keys(trackedUsers).length === 0) return;
+
         console.log("Checking for new AniList activity...");
         for (const channelId in trackedUsers) {
             for (const anilistUserId in trackedUsers[channelId]) {
@@ -1013,6 +1030,9 @@ async function startBot() {
 
         // WAL mode = better concurrent reads + crash resistance.
         await db.exec("PRAGMA journal_mode = WAL;");
+        // synchronous=NORMAL fsyncs at COMMIT (default with WAL, but stated
+        // explicitly so a future PRAGMA tweak doesn't quietly weaken durability).
+        await db.exec("PRAGMA synchronous = NORMAL;");
 
         await db.exec(
             `CREATE TABLE IF NOT EXISTS tracked_users (

--- a/index.js
+++ b/index.js
@@ -1056,6 +1056,9 @@ async function startBot() {
         // synchronous=NORMAL fsyncs at COMMIT (default with WAL, but stated
         // explicitly so a future PRAGMA tweak doesn't quietly weaken durability).
         await db.exec("PRAGMA synchronous = NORMAL;");
+        // 5 second wait on lock contention (e.g. someone manually opens bot.db
+        // in `sqlite3` shell while the bot is live) before SQLITE_BUSY fires.
+        await db.exec("PRAGMA busy_timeout = 5000;");
 
         await db.exec(
             `CREATE TABLE IF NOT EXISTS tracked_users (

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
-﻿// sqlite async/await ke liye
+﻿// @ts-check
+// sqlite async/await ke liye
 const { open } = require("sqlite");
 const sqlite3 = require("sqlite3").verbose();
 
 // Token can come from Replit Secrets (env) or config.json. Env wins.
 // config.json is now optional — missing file is fine if env is set.
+/** @type {{ token?: string }} */
 let _configFile = {};
+// @ts-ignore — config.json is gitignored, so it may not exist at type-check time;
+// the try/catch handles the runtime "missing file" case.
 try { _configFile = require("./config.json"); } catch { /* file optional */ }
 const token = process.env.DISCORD_TOKEN ?? _configFile.token;
 if (!token) {
@@ -49,7 +53,7 @@ function checkSingleInstance() {
             const lockPid = fs.readFileSync(LOCK_FILE, 'utf8');
             try {
                 // Signal 0 = "is the process alive?" without actually killing it.
-                process.kill(lockPid, 0);
+                process.kill(parseInt(lockPid, 10), 0);
                 console.error(`❌ Another instance is already running (PID: ${lockPid}). Exiting...`);
                 process.exit(1);
             } catch (e) {
@@ -102,14 +106,19 @@ process.on("unhandledRejection", (error) => {
 // Globals & Discord client
 // =========================================================================
 
+/** @type {Object<string, Object<string, import("./lib/types").TrackedUser>>} */
 let trackedUsers = {}; // memory mein users ka data rakhe ga
-let db; // database ka instance
+/** @type {any} */
+let db; // database ka instance (sqlite Database — no exported type)
+/** @type {Object<string, import("discord.js").Webhook>} */
 let webhookCache = {}; // channelId -> Webhook
+/** @type {Object<string, import("./lib/types").ChannelPermissionsEntry>} */
 let permissionsCache = {}; // channelId -> { hasManageWebhooks, expiresAt }
 // Tracks (channelId:anilistUserId) pairs whose first successful poll has
 // already happened in *this* process. Re-armed by every restart, which is
 // the whole point: any backlog accumulated during downtime gets summarised
 // down to a single post per user instead of flooding the channel.
+/** @type {Set<string>} */
 const firstPollComplete = new Set();
 const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
 const PERMISSIONS_CACHE_TTL = 3600000; // 1 hour — channel perms drift slowly
@@ -160,9 +169,14 @@ function getPreferredTitle(mediaTitles, preference) {
  * Cached webhooks are revalidated on each call; deleted webhooks are evicted automatically.
  */
 async function getOrCreateWebhook(channel) {
+    // Narrow once in a local — TS doesn't preserve the null-check across the
+    // closures below.
+    const botUser = client.user;
+    if (!botUser) return null;
     if (webhookCache[channel.id]) {
         try {
             // Revalidate — webhook may have been deleted out from under us.
+            // @ts-ignore — Webhook.fetch() exists at runtime; v14 types omit it
             await webhookCache[channel.id].fetch();
             return webhookCache[channel.id];
         } catch (error) {
@@ -179,7 +193,7 @@ async function getOrCreateWebhook(channel) {
         if (cached && cached.expiresAt > now) {
             hasManageWebhooks = cached.hasManageWebhooks;
         } else {
-            hasManageWebhooks = channel.permissionsFor(client.user)
+            hasManageWebhooks = channel.permissionsFor(botUser)
                 .has(PermissionsBitField.Flags.ManageWebhooks);
             permissionsCache[channel.id] = {
                 hasManageWebhooks,
@@ -192,7 +206,7 @@ async function getOrCreateWebhook(channel) {
         }
 
         const webhooks = await channel.fetchWebhooks();
-        let webhook = webhooks.find(wh => wh.owner?.id === client.user.id && wh.name === 'AniList Activity');
+        let webhook = webhooks.find(wh => wh.owner?.id === botUser.id && wh.name === 'AniList Activity');
 
         if (!webhook) {
             webhook = await channel.createWebhook({
@@ -271,6 +285,7 @@ async function sendActivityUpdate(channel, anilistUsername, userAvatar, embed) {
  * re-evaluated next tick.
  */
 async function checkAniListActivity(channelId, anilistUserId) {
+    if (!client.user) return; // before ready — narrow for TS, also defensive
     const trackingInfo = trackedUsers[channelId]?.[anilistUserId];
     if (!trackingInfo) return;
 
@@ -419,7 +434,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
                             .setColor(embedColor)
                             .setAuthor({
                                 name: `${anilistUsername}'s Activity`,
-                                iconURL: currentAvatar,
+                                iconURL: currentAvatar ?? undefined,
                                 url: `https://anilist.co/user/${anilistUsername}/`,
                             })
                             .setDescription(description)
@@ -481,6 +496,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
 // =========================================================================
 
 client.on(Events.ClientReady, () => {
+    if (!client.user) return; // unreachable in practice, but narrows client.user for TS
     console.log(`Logged in as ${client.user.tag}!`);
 
     client.user.setActivity('/help');

--- a/index.js
+++ b/index.js
@@ -94,6 +94,11 @@ let trackedUsers = {}; // memory mein users ka data rakhe ga
 let db; // database ka instance
 let webhookCache = {}; // channelId -> Webhook
 let permissionsCache = {}; // channelId -> { hasManageWebhooks, expiresAt }
+// Tracks (channelId:anilistUserId) pairs whose first successful poll has
+// already happened in *this* process. Re-armed by every restart, which is
+// the whole point: any backlog accumulated during downtime gets summarised
+// down to a single post per user instead of flooding the channel.
+const firstPollComplete = new Set();
 const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
 const PERMISSIONS_CACHE_TTL = 3600000; // 1 hour — channel perms drift slowly
 
@@ -261,6 +266,8 @@ async function checkAniListActivity(channelId, anilistUserId) {
     const url = "https://graphql.anilist.co";
     const filter = activityFilter || "both";
     const now = Date.now();
+    const userKey = `${channelId}:${anilistUserId}`;
+    const isFirstPoll = !firstPollComplete.has(userKey);
 
     // Profile data 24h baad refresh karte hain — saves ~98% of profile-only API calls.
     const needsProfileRefresh = !profileLastUpdated || (now - profileLastUpdated) > PROFILE_CACHE_DURATION;
@@ -369,6 +376,18 @@ async function checkAniListActivity(channelId, anilistUserId) {
             }
             // 'both' => no filter
 
+            // First-poll backlog guard. After a redeploy, any pending backlog
+            // is summarised down to the most recent activity so the channel
+            // doesn't get flooded by downtime catch-up. Re-armed every restart.
+            if (isFirstPoll && newActivities.length > 1) {
+                const skipped = newActivities.length - 1;
+                console.log(
+                    `🔧 Startup catch-up for ${anilistUsername}: posting most recent only, ` +
+                    `skipping ${skipped} backlog activit${skipped === 1 ? 'y' : 'ies'}.`,
+                );
+                newActivities = [newActivities[0]];
+            }
+
             if (newActivities.length > 0) {
                 // 15 ka cap so a long absence can't dump 50 posts at once.
                 const activitiesToShow = newActivities.slice(0, 15);
@@ -441,6 +460,10 @@ async function checkAniListActivity(channelId, anilistUserId) {
                 }
             }
         }
+
+        // Successful round-trip — guard is now consumed for this user.
+        // (A throw skips this line, so failed first polls re-arm themselves.)
+        firstPollComplete.add(userKey);
     } catch (error) {
         console.error(`Error fetching activity for ${anilistUsername}:`, error);
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// sqlite async/await ke liye
+﻿// sqlite async/await ke liye
 const { open } = require("sqlite");
 const sqlite3 = require("sqlite3").verbose();
 
@@ -23,6 +23,10 @@ const {
 // Node 20+ provides a global `fetch` — no node-fetch dep needed.
 const fs = require("fs");
 const path = require("path");
+
+const { aniListFetch } = require("./lib/anilist");
+const commands = require("./commands");
+const commandMap = new Map(commands.map(c => [c.data.name, c]));
 
 // =========================================================================
 // Single-instance lock
@@ -110,20 +114,6 @@ const firstPollComplete = new Set();
 const PROFILE_CACHE_DURATION = 86400000; // 24 hours in ms
 const PERMISSIONS_CACHE_TTL = 3600000; // 1 hour — channel perms drift slowly
 
-// AniList rate-limit gate. Updated when the API returns 429; while
-// `Date.now() < rateLimitedUntil`, every aniListFetch short-circuits.
-let rateLimitedUntil = 0;
-
-// Marker error so callers can distinguish "AniList told us to wait" from
-// generic network failures and respond with a friendly retry hint.
-class RateLimitError extends Error {
-    constructor(retryAfterMs) {
-        super(`AniList rate-limited for another ~${Math.ceil(retryAfterMs / 1000)}s`);
-        this.name = "RateLimitError";
-        this.retryAfterMs = retryAfterMs;
-    }
-}
-
 // AniList profile colors ko hex codes mein convert karne ke liye mapping
 const anilistColorMap = {
     blue: "#3DB4F2",
@@ -158,52 +148,6 @@ function getPreferredTitle(mediaTitles, preference) {
         default:
             return mediaTitles.romaji || mediaTitles.english || mediaTitles.native;
     }
-}
-
-// =========================================================================
-// AniList client
-// =========================================================================
-
-/**
- * POST a GraphQL query to AniList with rate-limit awareness.
- * Throws RateLimitError when we know we'd be denied (gate is active, or
- * the response itself returns 429). On success returns the parsed JSON.
- *
- * AniList's per-IP limit is 90 requests/minute and is communicated via
- * `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers.
- */
-async function aniListFetch(query, variables) {
-    const now = Date.now();
-    if (now < rateLimitedUntil) {
-        throw new RateLimitError(rateLimitedUntil - now);
-    }
-
-    const response = await fetch("https://graphql.anilist.co", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-        },
-        body: JSON.stringify({ query, variables }),
-    });
-
-    const remainingHeader = response.headers.get("x-ratelimit-remaining");
-    const remaining = remainingHeader != null ? parseInt(remainingHeader, 10) : NaN;
-    if (Number.isFinite(remaining) && remaining < 10) {
-        console.warn(`⚠️ AniList rate limit low: ${remaining} requests remaining.`);
-    }
-
-    if (response.status === 429) {
-        const resetSec = parseInt(response.headers.get("x-ratelimit-reset") ?? "0", 10);
-        rateLimitedUntil = Number.isFinite(resetSec) && resetSec > 0
-            ? resetSec * 1000
-            : Date.now() + 60_000; // 60s fallback if header missing
-        const waitMs = rateLimitedUntil - Date.now();
-        console.warn(`⚠️ AniList returned 429. Backing off for ~${Math.ceil(waitMs / 1000)}s.`);
-        throw new RateLimitError(waitMs);
-    }
-
-    return response.json();
 }
 
 // =========================================================================
@@ -592,14 +536,12 @@ client.on(Events.ClientReady, () => {
 
 client.on("interactionCreate", async (interaction) => {
     if (!interaction.isChatInputCommand()) return;
-    const { commandName } = interaction;
+    const cmd = commandMap.get(interaction.commandName);
+    if (!cmd) return;
 
     try {
-        // /list, /help, /untrack are management — keep them ephemeral.
         await interaction.deferReply({
-            flags: ["list", "help", "untrack"].includes(commandName)
-                ? [MessageFlags.Ephemeral]
-                : undefined,
+            flags: cmd.ephemeral ? [MessageFlags.Ephemeral] : undefined,
         });
     } catch (error) {
         console.error(
@@ -609,458 +551,19 @@ client.on("interactionCreate", async (interaction) => {
         return;
     }
 
+    // Bag of runtime references for command handlers.
+    const ctx = {
+        client,
+        db,
+        trackedUsers,
+        webhookCache,
+        permissionsCache,
+        checkAniListActivity,
+        commands,
+    };
+
     try {
-        if (commandName === "help") {
-            const helpEmbed = new EmbedBuilder()
-                .setColor("#C3B1E1")
-                .setTitle("AniList Bot Commands")
-                .addFields(
-                    {
-                        name: "/track <username> [filter]",
-                        value: "Starts tracking a user's activity. Optional filter: anime, manga, or both (default).",
-                    },
-                    {
-                        name: "/untrack <username>",
-                        value: "Stops tracking a specific user in this channel.",
-                    },
-                    {
-                        name: "/list",
-                        value: "Shows all AniList users currently being tracked in this channel.",
-                    },
-                    {
-                        name: "/stats <username>",
-                        value: "Shows detailed statistics for an AniList user.",
-                    },
-                    {
-                        name: "/serverstats",
-                        value: "Shows statistics for all tracked users in this server.",
-                    },
-                    { name: "/help", value: "Displays this list of commands." },
-                );
-            await interaction.editReply({ embeds: [helpEmbed] });
-        } else if (commandName === "list") {
-            const usersInChannel = trackedUsers[interaction.channelId];
-            const listEmbed = new EmbedBuilder()
-                .setColor("#C3B1E1")
-                .setTitle(`AniList Users Tracked in this Channel`);
-            if (usersInChannel && Object.keys(usersInChannel).length > 0) {
-                listEmbed.setDescription(
-                    Object.values(usersInChannel)
-                        .map((user) => {
-                            const filterEmoji = user.activityFilter === 'anime' ? '📺' :
-                                              user.activityFilter === 'manga' ? '📖' : '📺📖';
-                            const filterText = user.activityFilter === 'both' ? '' :
-                                             ` (${user.activityFilter} only)`;
-                            return `• ${filterEmoji} **${user.anilistUsername}**${filterText}`;
-                        })
-                        .join("\n"),
-                );
-            } else {
-                listEmbed.setDescription(
-                    "No users are currently being tracked in this channel.",
-                );
-            }
-            await interaction.editReply({ embeds: [listEmbed] });
-        } else if (commandName === "track") {
-            const anilistUsername = interaction.options.getString("username");
-            const activityFilter = interaction.options.getString("filter") || "both";
-            const channelId = interaction.channelId;
-
-            // Lookup ID + profile (avatar/color/titleLanguage) in a single query.
-            const findUserQuery = `query ($username: String) { 
-                User(name: $username) { 
-                    id 
-                    avatar { large }
-                    options { profileColor, titleLanguage }
-                } 
-            }`;
-            const data = await aniListFetch(findUserQuery, { username: anilistUsername });
-            if (!data.data || !data.data.User)
-                return interaction.editReply(
-                    `Could not find an AniList user with the username **${anilistUsername}**. Please check spelling.`,
-                );
-
-            const anilistUserId = data.data.User.id;
-            const userAvatar = data.data.User.avatar?.large;
-            const userColor = data.data.User.options?.profileColor;
-            const titleLanguage = data.data.User.options?.titleLanguage || "ROMAJI";
-            const now = Date.now();
-
-            if (trackedUsers[channelId]?.[anilistUserId])
-                return interaction.editReply(
-                    `**${anilistUsername}** is already being tracked in this channel.`,
-                );
-
-            const sql = `INSERT INTO tracked_users (channelId, anilistUsername, anilistUserId, lastActivityId, userAvatar, userColor, titleLanguage, profileLastUpdated, activityFilter) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-            await db.run(sql, [
-                channelId,
-                anilistUsername,
-                anilistUserId,
-                null,
-                userAvatar,
-                userColor,
-                titleLanguage,
-                now,
-                activityFilter,
-            ]);
-
-            // FULL checkpoint — user-facing write, must survive a kill.
-            await db.exec("PRAGMA wal_checkpoint(FULL);");
-
-            const verification = await db.get(
-                `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
-                [channelId, anilistUserId]
-            );
-
-            if (verification) {
-                console.log(
-                    `✓ [SUCCESS] Database write for ${anilistUsername} completed and verified.`,
-                );
-                if (!trackedUsers[channelId]) trackedUsers[channelId] = {};
-                trackedUsers[channelId][anilistUserId] = {
-                    anilistUsername: anilistUsername,
-                    lastActivityId: null,
-                    userAvatar: userAvatar,
-                    userColor: userColor,
-                    titleLanguage: titleLanguage,
-                    profileLastUpdated: now,
-                    activityFilter: activityFilter,
-                };
-            } else {
-                console.error(
-                    `✗ [ERROR] Database write verification failed for ${anilistUsername}!`,
-                );
-                throw new Error("Failed to persist user to database");
-            }
-            const filterText = activityFilter === 'both' ? 'all activity' :
-                              activityFilter === 'anime' ? 'anime only' : 'manga only';
-            await interaction.editReply(
-                `Successfully found **${anilistUsername}**. Now tracking their ${filterText} in this channel!`,
-            );
-            checkAniListActivity(channelId, anilistUserId);
-        } else if (commandName === "untrack") {
-            const usernameToUntrack = interaction.options.getString("username");
-            const channelId = interaction.channelId;
-            const usersInChannel = trackedUsers[channelId];
-            if (!usersInChannel)
-                return interaction.editReply({
-                    content:
-                        "No users are currently being tracked in this channel.",
-                });
-            let userToUntrackInfo = null,
-                userIdToUntrack = null;
-            for (const userId in usersInChannel) {
-                if (
-                    usersInChannel[userId].anilistUsername.toLowerCase() ===
-                    usernameToUntrack.toLowerCase()
-                ) {
-                    userToUntrackInfo = usersInChannel[userId];
-                    userIdToUntrack = userId;
-                    break;
-                }
-            }
-            if (!userToUntrackInfo)
-                return interaction.editReply({
-                    content: `**${usernameToUntrack}** is not being tracked in this channel.`,
-                });
-            const sql = `DELETE FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`;
-            await db.run(sql, [channelId, userIdToUntrack]);
-
-            // FULL checkpoint — user-facing write, must survive a kill.
-            await db.exec("PRAGMA wal_checkpoint(FULL);");
-
-            const verification = await db.get(
-                `SELECT * FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
-                [channelId, userIdToUntrack]
-            );
-
-            if (!verification) {
-                console.log(
-                    `✓ Successfully deleted ${userToUntrackInfo.anilistUsername} from database (verified).`,
-                );
-                delete trackedUsers[channelId][userIdToUntrack];
-                if (Object.keys(trackedUsers[channelId]).length === 0) {
-                    delete trackedUsers[channelId];
-                    // Channel ab khaali hai — per-channel caches bhi drop kar do
-                    // taake long-running deploys mein stale entries jama na hon.
-                    delete webhookCache[channelId];
-                    delete permissionsCache[channelId];
-                }
-                await interaction.editReply(
-                    `Stopped tracking **${userToUntrackInfo.anilistUsername}** in this channel.`,
-                );
-            } else {
-                console.error(
-                    `✗ Database delete verification failed for ${userToUntrackInfo.anilistUsername}!`,
-                );
-                await interaction.editReply(
-                    `Error: Failed to remove **${userToUntrackInfo.anilistUsername}** from database.`,
-                );
-            }
-        } else if (commandName === "stats") {
-            const anilistUsername = interaction.options.getString("username");
-
-            const statsQuery = `query ($username: String) {
-                User(name: $username) {
-                    id
-                    name
-                    avatar { large }
-                    bannerImage
-                    statistics {
-                        anime {
-                            count
-                            episodesWatched
-                            minutesWatched
-                            meanScore
-                            standardDeviation
-                        }
-                        manga {
-                            count
-                            chaptersRead
-                            volumesRead
-                            meanScore
-                            standardDeviation
-                        }
-                    }
-                    favourites {
-                        anime { nodes { title { romaji } } }
-                        manga { nodes { title { romaji } } }
-                        characters { nodes { name { full } } }
-                    }
-                }
-            }`;
-
-            try {
-                const data = await aniListFetch(statsQuery, { username: anilistUsername });
-
-                if (!data.data || !data.data.User) {
-                    return interaction.editReply(
-                        `Could not find an AniList user with the username **${anilistUsername}**.`
-                    );
-                }
-
-                const user = data.data.User;
-                const animeStats = user.statistics.anime;
-                const mangaStats = user.statistics.manga;
-
-                const daysWatched = (animeStats.minutesWatched / 1440).toFixed(1);
-
-                const favAnime = user.favourites.anime.nodes
-                    .slice(0, 3)
-                    .map(a => a.title.romaji)
-                    .join(", ") || "None";
-
-                const favManga = user.favourites.manga.nodes
-                    .slice(0, 3)
-                    .map(m => m.title.romaji)
-                    .join(", ") || "None";
-
-                const favChar = user.favourites.characters.nodes[0]?.name.full || "None";
-
-                const statsEmbed = new EmbedBuilder()
-                    .setColor("#C3B1E1")
-                    .setAuthor({
-                        name: `${user.name}'s AniList Statistics`,
-                        iconURL: user.avatar.large,
-                        url: `https://anilist.co/user/${user.name}/`,
-                    })
-                    .addFields(
-                        {
-                            name: "📺 Anime Statistics",
-                            value: [
-                                `**Total Anime:** ${animeStats.count}`,
-                                `**Episodes Watched:** ${animeStats.episodesWatched.toLocaleString()}`,
-                                `**Days Watched:** ${daysWatched}`,
-                                `**Mean Score:** ${animeStats.meanScore.toFixed(1)}`,
-                            ].join("\n"),
-                            inline: true,
-                        },
-                        {
-                            name: "📖 Manga Statistics",
-                            value: [
-                                `**Total Manga:** ${mangaStats.count}`,
-                                `**Chapters Read:** ${mangaStats.chaptersRead.toLocaleString()}`,
-                                `**Volumes Read:** ${mangaStats.volumesRead.toLocaleString()}`,
-                                `**Mean Score:** ${mangaStats.meanScore.toFixed(1)}`,
-                            ].join("\n"),
-                            inline: true,
-                        },
-                        {
-                            name: "⭐ Favorites",
-                            value: [
-                                `**Anime:** ${favAnime}`,
-                                `**Manga:** ${favManga}`,
-                                `**Character:** ${favChar}`,
-                            ].join("\n"),
-                        }
-                    );
-
-                if (user.bannerImage) {
-                    statsEmbed.setImage(user.bannerImage);
-                }
-
-                await interaction.editReply({ embeds: [statsEmbed] });
-            } catch (error) {
-                console.error(`Error fetching stats for ${anilistUsername}:`, error);
-                await interaction.editReply(
-                    `There was an error fetching statistics for **${anilistUsername}**.`
-                );
-            }
-        } else if (commandName === "serverstats") {
-            // Collect every unique AniList user tracked anywhere in this guild
-            // (a user may be tracked in multiple channels — dedupe by AniList ID).
-            const guildId = interaction.guildId;
-            const allChannelsInGuild = Object.keys(trackedUsers);
-            const uniqueUsers = new Map();
-
-            for (const channelId of allChannelsInGuild) {
-                try {
-                    const channel = await client.channels.fetch(channelId);
-                    if (channel && channel.guildId === guildId) {
-                        for (const userId in trackedUsers[channelId]) {
-                            const user = trackedUsers[channelId][userId];
-                            if (!uniqueUsers.has(userId)) {
-                                uniqueUsers.set(userId, user.anilistUsername);
-                            }
-                        }
-                    }
-                } catch (error) {
-                    // Channel inaccessible — skip silently and continue.
-                    continue;
-                }
-            }
-
-            if (uniqueUsers.size === 0) {
-                return interaction.editReply(
-                    "No users are currently being tracked in this server."
-                );
-            }
-
-            const userIds = Array.from(uniqueUsers.keys());
-            console.log(`Fetching server stats for ${userIds.length} users:`, userIds);
-
-            // AniList's schema doesn't expose a multi-User field, so we fan out
-            // one query per user and Promise.all the lot.
-            const userDataPromises = userIds.map(async (userId) => {
-                const userQuery = `query ($id: Int) {
-                    User(id: $id) {
-                        id
-                        name
-                        avatar {
-                            medium
-                        }
-                        statistics {
-                            anime {
-                                count
-                                episodesWatched
-                                minutesWatched
-                                meanScore
-                            }
-                            manga {
-                                count
-                                chaptersRead
-                            }
-                        }
-                    }
-                }`;
-
-                try {
-                    const data = await aniListFetch(userQuery, { id: parseInt(userId) });
-                    return data.data?.User || null;
-                } catch (error) {
-                    if (error.name !== "RateLimitError") {
-                        console.error(`Error fetching user ${userId}:`, error);
-                    }
-                    return null;
-                }
-            });
-
-            try {
-                const usersData = await Promise.all(userDataPromises);
-                const users = usersData.filter(u => u !== null);
-
-                if (users.length === 0) {
-                    // Distinguish rate-limit drought from genuine no-data.
-                    if (Date.now() < rateLimitedUntil) {
-                        const sec = Math.ceil((rateLimitedUntil - Date.now()) / 1000);
-                        return interaction.editReply(
-                            `AniList is temporarily rate-limiting us. Try again in ~${sec}s.`
-                        );
-                    }
-                    return interaction.editReply(
-                        "No data available for tracked users in this server."
-                    );
-                }
-
-                let totalAnime = 0;
-                let totalEpisodes = 0;
-                let totalManga = 0;
-                let totalChapters = 0;
-                let totalMinutes = 0;
-                let avgScore = 0;
-
-                users.forEach(user => {
-                    totalAnime += user.statistics.anime.count;
-                    totalEpisodes += user.statistics.anime.episodesWatched;
-                    totalManga += user.statistics.manga.count;
-                    totalChapters += user.statistics.manga.chaptersRead;
-                    totalMinutes += user.statistics.anime.minutesWatched;
-                    avgScore += user.statistics.anime.meanScore;
-                });
-
-                avgScore = (avgScore / users.length).toFixed(1);
-                const totalDays = (totalMinutes / 1440).toFixed(1);
-
-                const topWatchers = users
-                    .sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)
-                    .slice(0, 5)
-                    .map((u, i) => {
-                        const avatarEmoji = u.avatar?.medium ? `[🎭](${u.avatar.medium})` : '👤';
-                        return `${i + 1}. ${avatarEmoji} **[${u.name}](https://anilist.co/user/${u.name})** - ${u.statistics.anime.count} anime`;
-                    })
-                    .join("\n");
-
-                const topUser = users.sort((a, b) => b.statistics.anime.count - a.statistics.anime.count)[0];
-
-                const serverStatsEmbed = new EmbedBuilder()
-                    .setColor("#C3B1E1")
-                    .setTitle(`📊 Server AniList Statistics`)
-                    .setDescription(`Tracking **${uniqueUsers.size}** users in this server`)
-                    .addFields(
-                        {
-                            name: "📺 Combined Anime Stats",
-                            value: [
-                                `**Total Anime Watched:** ${totalAnime.toLocaleString()}`,
-                                `**Total Episodes:** ${totalEpisodes.toLocaleString()}`,
-                                `**Total Days Watched:** ${totalDays}`,
-                                `**Average Score:** ${avgScore}`,
-                            ].join("\n"),
-                            inline: true,
-                        },
-                        {
-                            name: "📖 Combined Manga Stats",
-                            value: [
-                                `**Total Manga Read:** ${totalManga.toLocaleString()}`,
-                                `**Total Chapters:** ${totalChapters.toLocaleString()}`,
-                            ].join("\n"),
-                            inline: true,
-                        },
-                        {
-                            name: "🏆 Top Watchers",
-                            value: topWatchers,
-                        }
-                    )
-                    .setThumbnail(topUser?.avatar?.medium || null)
-                    .setTimestamp();
-
-                await interaction.editReply({ embeds: [serverStatsEmbed] });
-            } catch (error) {
-                console.error("Error fetching server stats:", error.message, error.stack);
-                await interaction.editReply(
-                    `There was an error fetching server statistics: ${error.message}`
-                );
-            }
-        }
+        await cmd.execute(interaction, ctx);
     } catch (error) {
         // RateLimitError is expected and already logged at source — give the
         // user a clear "try again in Xs" instead of a generic failure.
@@ -1076,7 +579,7 @@ client.on("interactionCreate", async (interaction) => {
             return;
         }
         console.error(
-            `An error occurred while executing the /${commandName} command:`,
+            `An error occurred while executing the /${interaction.commandName} command:`,
             error,
         );
         try {

--- a/lib/anilist.js
+++ b/lib/anilist.js
@@ -1,3 +1,4 @@
+// @ts-check
 // AniList GraphQL client + rate-limit gate.
 // Module-level state (`rateLimitedUntil`) is intentionally process-global so a
 // 429 hit in any one fetch site (polling loop, /track, /stats, /serverstats)

--- a/lib/anilist.js
+++ b/lib/anilist.js
@@ -1,0 +1,72 @@
+// AniList GraphQL client + rate-limit gate.
+// Module-level state (`rateLimitedUntil`) is intentionally process-global so a
+// 429 hit in any one fetch site (polling loop, /track, /stats, /serverstats)
+// short-circuits all other sites until the reset window passes.
+
+let rateLimitedUntil = 0;
+
+/**
+ * Marker error so callers can distinguish "AniList told us to wait" from
+ * generic network failures and respond with a friendly retry hint.
+ */
+class RateLimitError extends Error {
+    constructor(retryAfterMs) {
+        super(`AniList rate-limited for another ~${Math.ceil(retryAfterMs / 1000)}s`);
+        this.name = "RateLimitError";
+        this.retryAfterMs = retryAfterMs;
+    }
+}
+
+/**
+ * Returns the remaining rate-limit window in ms, or 0 if not currently limited.
+ * Useful for code paths that don't catch RateLimitError directly (e.g. a
+ * Promise.all that swallows per-promise rejections) and need to ask out-of-band
+ * whether the gate is active.
+ */
+function getRateLimitRemainingMs() {
+    return Math.max(0, rateLimitedUntil - Date.now());
+}
+
+/**
+ * POST a GraphQL query to AniList with rate-limit awareness.
+ * Throws RateLimitError when we know we'd be denied (gate is active, or
+ * the response itself returns 429). On success returns the parsed JSON.
+ *
+ * AniList's per-IP limit is 90 requests/minute and is communicated via
+ * `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers.
+ */
+async function aniListFetch(query, variables) {
+    const remainingMs = getRateLimitRemainingMs();
+    if (remainingMs > 0) {
+        throw new RateLimitError(remainingMs);
+    }
+
+    const response = await fetch("https://graphql.anilist.co", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+    });
+
+    const remainingHeader = response.headers.get("x-ratelimit-remaining");
+    const remaining = remainingHeader != null ? parseInt(remainingHeader, 10) : NaN;
+    if (Number.isFinite(remaining) && remaining < 10) {
+        console.warn(`⚠️ AniList rate limit low: ${remaining} requests remaining.`);
+    }
+
+    if (response.status === 429) {
+        const resetSec = parseInt(response.headers.get("x-ratelimit-reset") ?? "0", 10);
+        rateLimitedUntil = Number.isFinite(resetSec) && resetSec > 0
+            ? resetSec * 1000
+            : Date.now() + 60_000;
+        const waitMs = rateLimitedUntil - Date.now();
+        console.warn(`⚠️ AniList returned 429. Backing off for ~${Math.ceil(waitMs / 1000)}s.`);
+        throw new RateLimitError(waitMs);
+    }
+
+    return response.json();
+}
+
+module.exports = { aniListFetch, RateLimitError, getRateLimitRemainingMs };

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,51 @@
+// @ts-check
+// JSDoc-only module. No runtime exports — this file exists purely as the
+// canonical anchor for project-wide @typedef declarations. Other files
+// reference these types via `import("./lib/types").TypeName` in JSDoc.
+
+/**
+ * One row of the tracked_users table, after hydration into the in-memory cache.
+ *
+ * @typedef {Object} TrackedUser
+ * @property {string}      anilistUsername
+ * @property {number|null} lastActivityId
+ * @property {string|null} userAvatar
+ * @property {string|null} userColor
+ * @property {string}      titleLanguage      ROMAJI | ENGLISH | NATIVE | ROMAJI_STYLISED
+ * @property {number|null} profileLastUpdated  ms timestamp of last AniList profile fetch
+ * @property {string}      activityFilter     "both" | "anime" | "manga"
+ */
+
+/**
+ * Cached webhook permission state for a single channel.
+ *
+ * @typedef {Object} ChannelPermissionsEntry
+ * @property {boolean} hasManageWebhooks
+ * @property {number}  expiresAt ms timestamp when the entry should be re-checked
+ */
+
+/**
+ * Bag of runtime references passed into every command's `execute` function.
+ * Built freshly per interaction inside the dispatcher so commands always see
+ * the live `db` and shared caches without each having to import them.
+ *
+ * @typedef {Object} CommandCtx
+ * @property {import("discord.js").Client}                                            client
+ * @property {any}                                                                    db                   sqlite Database (untyped — `sqlite` package's types aren't exported)
+ * @property {Object<string, Object<string, TrackedUser>>}                            trackedUsers
+ * @property {Object<string, import("discord.js").Webhook>}                           webhookCache
+ * @property {Object<string, ChannelPermissionsEntry>}                                permissionsCache
+ * @property {(channelId: string, anilistUserId: string|number) => Promise<void>}     checkAniListActivity
+ * @property {Array<CommandModule>}                                                   commands
+ */
+
+/**
+ * The shape every file in commands/ must export.
+ *
+ * @typedef {Object} CommandModule
+ * @property {import("discord.js").SlashCommandBuilder | import("discord.js").SlashCommandOptionsOnlyBuilder | import("discord.js").SlashCommandSubcommandsOnlyBuilder} data
+ * @property {boolean} [ephemeral]  whether the deferReply should be flagged ephemeral (default: false)
+ * @property {(interaction: import("discord.js").ChatInputCommandInteraction, ctx: CommandCtx) => Promise<unknown>} execute
+ */
+
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,11 @@
         "@discordjs/rest": "^2.5.1",
         "discord-api-types": "^0.38.16",
         "discord.js": "^14.21.0",
-        "dotenv": "^17.2.0",
-        "node-fetch": "^2.7.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -575,18 +576,6 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {
@@ -1163,26 +1152,6 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -1684,12 +1653,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -1754,22 +1717,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=20"
+  },
   "bugs": {
     "url": "https://github.com/Abdullah-Mehdi/Asterism/issues"
   },
@@ -37,8 +40,6 @@
     "@discordjs/rest": "^2.5.1",
     "discord-api-types": "^0.38.16",
     "discord.js": "^14.21.0",
-    "dotenv": "^17.2.0",
-    "node-fetch": "^2.7.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   }


### PR DESCRIPTION
## Why

The bot's been running fine for months but had accumulated drift: a 1100-line `index.js` with the entire dispatcher inlined, a marketing-style README, dead dependencies (`node-fetch`, `dotenv`), redundant per-write SQLite checkpoints, and the redeploy-spam bug where a 30-minute downtime window meant 15 backlog activities per user got dumped into the channel on next start.

This branch addresses all of that, plus a follow-up polish pass for type safety and Replit hardening.

## What

Grouped by theme:

### Structure
- Extracted slash commands into `commands/` (one file per command) with an auto-loader at `commands/index.js`. Adding a command is now a single-file change.
- Extracted the AniList HTTP client into `lib/anilist.js` (shared rate-limit gate state).
- New `lib/types.js` holds JSDoc `@typedef`s (`TrackedUser`, `CommandCtx`, `CommandModule`, `ChannelPermissionsEntry`).
- `index.js` is now ~770 lines, almost all infrastructure (lock, DB, polling, ready, shutdown, dispatcher stub). Dispatcher is 6 lines + ctx + a RateLimitError-aware catch.
- `deploy-commands.js` reads `data.toJSON()` from the registry instead of duplicating slash-command definitions inline.
- Banner section headers and JSDoc on every non-trivial function. Bilingual inline comments preserved by intent.

### Durability
- New `firstPollComplete` set summarises any pending backlog to a single most-recent post per user on the first successful poll after launch. Re-armed every restart. **Fixes the redeploy-spam complaint.**
- Weekly `bot.db.backup` written via `fs.copyFileSync` — coarse insurance, single rotating file.
- `PRAGMA busy_timeout = 5000` for lock-contention insurance during manual `sqlite3` shell sessions.
- `PRAGMA synchronous = NORMAL` stated explicitly so a future PRAGMA tweak can't silently weaken durability.
- AniList rate-limit gate: a 429 sets a process-wide `rateLimitedUntil` from `X-RateLimit-Reset`; subsequent fetches short-circuit until the window passes. User commands surface a "try again in ~Xs" reply instead of a generic error.

### Replit cost trim
- Polling tick early-returns when no users are tracked.
- Removed redundant per-write `wal_checkpoint(PASSIVE)` calls; rely on the existing 30-min periodic checkpoint + FULL checkpoints on user-facing writes (`/track`, `/untrack`, migration, shutdown).
- GraphQL `perPage: 50 → 20` (cap is 15; 20 leaves a small filter buffer).
- Permissions cache (1-hour TTL) so `permissionsFor(client.user)` isn't recomputed every poll.
- Dropped `node-fetch` (Node 20 has global `fetch`) and `dotenv` (was declared but never required). Net `node_modules` footprint shrunk.
- Per-channel `webhookCache` and `permissionsCache` evicted on `/untrack` when the channel goes empty.

### Configuration
- Token now reads from `process.env.DISCORD_TOKEN` first, falls back to `config.json`. Same for `DISCORD_CLIENT_ID` in `deploy-commands.js`. `config.json` is fully optional now — Replit Secrets are encrypted at rest, plaintext file isn't.
- Switched `client.on("ready", ...)` to `client.on(Events.ClientReady, ...)` — forward-compatible with discord.js 14.22+ where `'ready'` is deprecated.
- Added `"engines": { "node": ">=20" }` to `package.json` to document the runtime requirement.

### Type checking
- `// @ts-check` on every project `.js` file. Each command's `execute(interaction, ctx)` has a JSDoc-typed signature; module-level state in `index.js` carries `@type` annotations.
- Real type fixes surfaced and fixed: `parseInt` the lock-file PID, `getString("...", true)` to narrow required option returns, `client.user` captured in a local for closure-safe narrowing, nullable `iconURL` coerced to `undefined`.

### Docs
- README rewritten in plainer voice (down from 334 to ~155 lines). Cut features-catalog, fictional performance numbers, stale line-number references, v4.0 changelog, future-features list.

## Behavioural changes operators will notice

1. **First post per user after a redeploy is the most recent activity only**, not the full backlog. Log line: `🔧 Startup catch-up for <user>: posting most recent only, skipping K backlog activities.` — expected, not an error.
2. **`bot.db.backup` appears in `$REPL_HOME` within seconds of startup** and refreshes weekly.
3. **Polling loop is silent when no users are tracked.**
4. **A 429 from AniList produces a single `⚠️ AniList returned 429` line** and then silence until the gate clears, instead of repeated per-user error logs.
5. `/help` is **auto-rendered from the command registry** — no more drift between the embed and the actual command list.

## Out of scope (intentionally)

- ESM (`"type": "module"`) - would force `config.json` import to be async; high churn, low value for a single-file bot.
- Splitting polling/DB into more files - pulled out commands and AniList client; the rest of `index.js` is cohesive infrastructure that doesn't gain from being split further.
- Migration framework - 5 idempotent ALTER blocks doesn't justify it yet.
- Structured (JSON) logging - the `✓` / `✗` / `⚠️` glyph convention is already grep-friendly.

## Files touched

- New: `commands/{index,track,untrack,list,help,stats,serverstats}.js`, `lib/{anilist,types}.js`
- Modified: `index.js`, `deploy-commands.js`, `package.json`, `package-lock.json`, `README.md`, `.gitignore`
- Modified (gitignored, won't appear in PR diff): `AGENTS.md`, `DEPLOYING.md`
- Deleted: `tracked_users.json`, `WRITING_PROFILE_ABDULLAH.md`, `AI_ASSISTANT_GUIDE copy.md`