### PR TITLE
Filter-reset bug: route SIGTERM through gracefulShutdown + filter-drift diagnostics

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ const LOCK_FILE = process.env.REPL_HOME ?
  * Acquire a process-wide lock at LOCK_FILE so only one bot instance runs.
  * If a live PID already owns the lock, exits with code 1.
  * Stale locks (PID no longer alive) are cleared and re-acquired.
- * Wires `exit`, `SIGINT`, `SIGTERM`, and `SIGQUIT` to clean up the lock.
+ * Wires `process.on('exit')` as a last-resort lock-unlink fallback;
+ * termination signals (SIGINT/SIGTERM/SIGQUIT/SIGHUP) are routed to
+ * `gracefulShutdown` separately at the bottom of the file.
  */
 function checkSingleInstance() {
     try {
@@ -66,24 +68,16 @@ function checkSingleInstance() {
         fs.writeFileSync(LOCK_FILE, process.pid.toString());
         console.log(`✓ Lock acquired (PID: ${process.pid})`);
 
+        // Last-resort lock cleanup — fires even if gracefulShutdown died mid-run.
+        // Termination signals (SIGINT/SIGTERM/SIGQUIT/SIGHUP) are wired to
+        // gracefulShutdown at the bottom of the file so the WAL gets a final
+        // checkpoint and the DB closes cleanly before we hit this path.
         process.on('exit', () => {
             try {
                 fs.unlinkSync(LOCK_FILE);
             } catch (e) {
                 // Cleanup-only path; swallow errors.
             }
-        });
-
-        ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(signal => {
-            process.on(signal, () => {
-                console.log(`\n${signal} received, cleaning up...`);
-                try {
-                    fs.unlinkSync(LOCK_FILE);
-                } catch (e) {
-                    // Cleanup-only path; swallow errors.
-                }
-                process.exit(0);
-            });
         });
 
     } catch (error) {
@@ -289,6 +283,27 @@ async function checkAniListActivity(channelId, anilistUserId) {
     const trackingInfo = trackedUsers[channelId]?.[anilistUserId];
     if (!trackingInfo) return;
 
+    // Defensive: activityFilter is the one field where stale memory would
+    // silently produce wrong-channel posts (anime activity in a manga-only
+    // channel and vice versa). Treat the DB as canonical for it on every
+    // poll and reconcile if drift is detected.
+    try {
+        const dbRow = await db.get(
+            `SELECT activityFilter FROM tracked_users WHERE channelId = ? AND anilistUserId = ?`,
+            [channelId, anilistUserId]
+        );
+        if (dbRow && dbRow.activityFilter && dbRow.activityFilter !== trackingInfo.activityFilter) {
+            console.warn(
+                `⚠️ Filter drift for ${trackingInfo.anilistUsername} in channel ${channelId}: ` +
+                `memory=${trackingInfo.activityFilter}, db=${dbRow.activityFilter}. Using DB.`
+            );
+            trackingInfo.activityFilter = dbRow.activityFilter;
+        }
+    } catch (e) {
+        // Best-effort — if the SELECT fails, fall back to memory.
+        console.warn(`Filter re-read failed for ${trackingInfo.anilistUsername}: ${e.message}`);
+    }
+
     const { anilistUsername, lastActivityId, userAvatar, userColor, titleLanguage, profileLastUpdated, activityFilter } = trackingInfo;
     const filter = activityFilter || "both";
     const now = Date.now();
@@ -412,7 +427,7 @@ async function checkAniListActivity(channelId, anilistUserId) {
                 const skippedCount = newActivities.length - activitiesToShow.length;
 
                 console.log(
-                    `${newActivities.length} new activity/activities for ${anilistUsername}` +
+                    `${newActivities.length} new activity/activities for ${anilistUsername} (filter: ${filter}, channel: ${channelId})` +
                     (skippedCount > 0 ? ` (showing ${activitiesToShow.length}, skipping ${skippedCount} older ones)` : ''),
                 );
                 const channel = await client.channels.fetch(channelId);
@@ -722,7 +737,7 @@ async function startBot() {
                 profileLastUpdated: row.profileLastUpdated,
                 activityFilter: row.activityFilter || "both",
             };
-            console.log(`  [${index + 1}] User: ${row.anilistUsername} (ID: ${row.anilistUserId}), LastActivityId: ${row.lastActivityId}, Channel: ${row.channelId}`);
+            console.log(`  [${index + 1}] User: ${row.anilistUsername} (ID: ${row.anilistUserId}), Filter: ${row.activityFilter ?? 'NULL'}, LastActivityId: ${row.lastActivityId}, Channel: ${row.channelId}`);
         });
 
         console.log(`=== DATABASE LOAD COMPLETE ===\n`);
@@ -740,7 +755,9 @@ async function startBot() {
 
 /**
  * Final WAL checkpoint, close the database, and remove the lock file.
- * Wired to SIGHUP only — SIGINT/SIGTERM/SIGQUIT are handled in checkSingleInstance().
+ * Wired to all termination signals (SIGINT/SIGTERM/SIGQUIT/SIGHUP) below,
+ * so a Replit redeploy gets a clean shutdown instead of bypassing the WAL
+ * checkpoint and db.close().
  */
 async function gracefulShutdown(signal) {
     console.log(`\n${signal} received. Closing database and shutting down gracefully...`);
@@ -765,7 +782,12 @@ async function gracefulShutdown(signal) {
     }
 }
 
-process.on('SIGHUP', () => gracefulShutdown('SIGHUP'));
+// All termination signals route through gracefulShutdown so a Replit redeploy
+// (which sends SIGTERM) gets a proper WAL checkpoint + db.close() instead of
+// just unlinking the lock and exiting with un-checkpointed writes.
+['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP'].forEach(signal => {
+    process.on(signal, () => gracefulShutdown(signal));
+});
 
 // bot shuru karte hain
 startBot();


### PR DESCRIPTION
## What was reported

When the bot is redeployed on Replit, a server tracking the same AniList user across two channels with different filters (e.g. Alice in `#anime` with `filter=anime`, Alice in `#manga` with `filter=manga`) appears to lose its per-channel filter setup - both channels start posting all activity types, as if the filter reset to the default `'both'`.

## What I found (and didn't)

I read every code path that touches `activityFilter`: the `INSERT` in `commands/track.js`, the SELECT-verify after `/track`, the hydration loop in `index.js`, and the polling-loop filter application. The schema's composite PK `(channelId, anilistUserId)` is in place, the writes are correct, and the polling loop never mutates `activityFilter`.

**I could not reproduce the bug from static code analysis.** The same-user-two-channels case works as designed, and `/list` after re-tracking confirms the in-memory + DB state is correct. So either the bug was a one-off historical artefact (likely the `activityFilter` `ADD COLUMN ... DEFAULT 'both'` migration defaulting pre-existing rows the first time it ran, after which manual re-tracking corrected it), or there's a runtime cause that needs Replit logs from the bad redeploy to nail down.

## What this PR actually does

Three concrete changes on top of one workflow-doc update. None of them claim to be the confirmed fix; together they're (a) the strongest candidate cause I could identify, plus (b) the instrumentation needed to pin the actual cause if it recurs.

### 1. Route SIGINT/SIGTERM/SIGQUIT/SIGHUP through `gracefulShutdown`

The likely actual fix. Previously `checkSingleInstance` registered an inline handler for `SIGINT`/`SIGTERM`/`SIGQUIT` that just unlinked the lock file and exited - bypassing `gracefulShutdown` entirely. Replit redeploys send SIGTERM, so every redeploy was exiting without `PRAGMA wal_checkpoint(FULL)` or `db.close()`. WAL recovery on next start usually rebuilds correctly, but "usually" is not the word you want around persistence - especially across the Run+Deploy boundary on Replit.

All four termination signals now route through `gracefulShutdown`, which already does the FULL checkpoint + db close + lock removal in the right